### PR TITLE
Create a template for the Overview document type

### DIFF
--- a/guidelines/content-guidelines/content-strategy.md
+++ b/guidelines/content-guidelines/content-strategy.md
@@ -41,9 +41,9 @@ Every independent Kyma component is a separate documentation topic. The only exc
 
 Each technical topic must have the following document types:
 
-**NOTE:** The Kyma content developers create templates for a given document type once there are at least two documents to use as a base for such a template.
+>**NOTE:** The Kyma content developers create templates for a given document type once there are at least two documents to use as a base for such a template.
 
-* **Overview** - Use it to describe the component in general. It serves as an entry point for the topic. Make sure it is short and descriptive.
+* [Overview](../templates/resources/overview.md) - Use it to describe the component in general. It serves as an entry point for the topic. Make sure it is short but descriptive.
 * **Architecture** - Use it to describe in detail the architecture of the component. Include a diagram in this document.
 * **Getting Started** - Use it to provide a clear step-by-step instruction that helps the user to understand a given concept better. The user must be able to go through all the steps of the document and complete them. There is no separate tutorial type. The document does not have to explicitly point out the example used as, at the end, the explicit reference to the example will be in the main content of the guide.
 * **Details** - Use it to describe more technical details of the component that do not fit into any other document type. Among other things, include a detailed explanation of the application lifecycle that describes how the resource is created and what other resources are created, how it is updated, how it is removed, and what each operation means from the technical point of view.

--- a/guidelines/templates/README.md
+++ b/guidelines/templates/README.md
@@ -17,6 +17,7 @@ The table provides an overview of the template names, the repository they refer 
 | [`kyma/docs`](https://github.com/kyma-project/kyma/tree/master/docs) | [`cli-reference.md`](./resources/cli-reference.md) | Use the template to describe the syntax and the use of CLI commands for a given component. |
 | [`kyma/docs`](https://github.com/kyma-project/kyma/tree/master/docs) | [`custom-resource.md`](./resources/custom-resource.md) | Use the template to describe a custom resource (CR) and its elements. |
 | No specific repository | [`Kyma-branded presentation template`](./resources/Kyma_presentation_template.pptx) | Use the official Kyma-branded presentation to talk about the project and present it to new audiences. |
+| [`kyma/docs`](https://github.com/kyma-project/kyma/tree/master/docs) | [`overview.md`](./resources/overview.md) | Use the template to introduce a Kyma component. | 
 
 >**NOTE:** Update the table each time you add a new template to the `resources` folder.
 

--- a/guidelines/templates/resources/cli-reference.md
+++ b/guidelines/templates/resources/cli-reference.md
@@ -3,15 +3,14 @@ title: CLI reference
 type: CLI reference
 ---
 
-> This document is a ready-to-use template for a Command Line Interface (CLI) reference document that describes the syntax and the use of CLI commands for a given Kyma component. Put the name of a reference resource and a component in place of {resourcename} and {Component Name}, respectively. Do the same for {CLI tool name} and replace it with `kubectl`, `kubeless`, or `svcat`, depending on the tool you use.
-For details, see the existing CLI reference document for the [Service Catalog](https://github.com/kyma-project/kyma/blob/master/docs/service-catalog/docs/030-cli-reference.md).
-
-> **NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
+>**NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
+>
+> This document is a ready-to-use template for a Command Line Interface (CLI) reference document type that describes the syntax and the use of CLI commands for a given Kyma component. Put the name of a reference resource and a component in place of {resourcename} and {Component Name}, respectively. Do the same for {CLI tool name} and replace it with `kubectl`, `kubeless`, or `svcat`, depending on the tool you use. Follow the `{000}-cli-reference.md` convention to name the document.
+For reference, see the existing document for the [Service Catalog](https://github.com/kyma-project/kyma/blob/master/docs/service-catalog/docs/030-cli-reference.md).
 
 Management of the {Component Name} is based on the custom resources specifically defined for Kyma. Manage all of these resources through `[{CLI tool name}](link)`.
 
 > Provide a link to [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/), [kubeless](https://kubeless.io/docs/quick-start/), or [svcat](https://github.com/kubernetes-incubator/service-catalog/blob/master/docs/cli.md), respectively.
-
 
 ## Details
 

--- a/guidelines/templates/resources/custom-resource.md
+++ b/guidelines/templates/resources/custom-resource.md
@@ -3,10 +3,10 @@ title: {CRD kind}
 type: Custom Resource
 ---
 
-> This document is a ready-to-use template for a custom resource (CR) document that provides a sample custom resource and description of its elements. Additionally, the document points to the Custom Resource Definition (CRD) used to create CRs of the given kind. For reference, see the existing documents for the [Installation](https://github.com/kyma-project/kyma/blob/master/docs/kyma/docs/040-installation-custom-resource.md) and the [Api](https://github.com/kyma-project/kyma/blob/master/docs/api-gateway/docs/011-api-custom-resource.md) CRs.
-
 > **NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
-
+>
+> This document is a ready-to-use template for a custom resource (CR) document type that provides a sample custom resource and description of its elements. Additionally, the document points to the Custom Resource Definition (CRD) used to create CRs of the given kind. Follow the `{000}-{CRD-kind}-custom-resource.md` convention to name the document.
+For reference, see the existing documents for the [Installation](https://github.com/kyma-project/kyma/blob/master/docs/kyma/docs/040-installation-custom-resource.md) and the [Api](https://github.com/kyma-project/kyma/blob/master/docs/api-gateway/docs/011-api-custom-resource.md) CRs.
 
 The {CRD name} Custom Resource Definition (CRD) is a detailed description of the kind of data and the format used to {provide the CRD description}. To get the up-to-date CRD and show the output in the yaml format, run this command:
 

--- a/guidelines/templates/resources/overview.md
+++ b/guidelines/templates/resources/overview.md
@@ -5,7 +5,7 @@ type: Overview
 
 >**NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
 >
-> This is as a template for the **Overview** document type that introduces a given Kyma component.
+> This is a template for the **Overview** document type that introduces a given Kyma component.
 >
 >  In the document:
 > * Describe the component in general.

--- a/guidelines/templates/resources/overview.md
+++ b/guidelines/templates/resources/overview.md
@@ -5,7 +5,7 @@ type: Overview
 
 >**NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
 >
-> This document is as a template for the **Overview** document type that introduces a given Kyma component.
+> This is as a template for the **Overview** document type that introduces a given Kyma component.
 >
 >  In the document:
 > * Describe the component in general.

--- a/guidelines/templates/resources/overview.md
+++ b/guidelines/templates/resources/overview.md
@@ -1,0 +1,17 @@
+---
+title: Overview
+type: Overview
+---
+
+>**NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
+>
+> This document is a ready-to-use template for the **Overview** document type that introduces a given Kyma component.
+>
+>  In the document:
+> * Describe the component in general.
+> * Provide its purpose and function.
+> * Be short but descriptive.
+> * Avoid headings.
+> * Follow the `{000}-overview-{component-name}.md` convention to name it.
+>
+> For reference, see the existing **Overview** document for the [Application Connector](https://github.com/kyma-project/kyma/blob/master/docs/application-connector/docs/001-overview-application-connector.md).

--- a/guidelines/templates/resources/overview.md
+++ b/guidelines/templates/resources/overview.md
@@ -5,7 +5,7 @@ type: Overview
 
 >**NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
 >
-> This document is a ready-to-use template for the **Overview** document type that introduces a given Kyma component.
+> This document is as a template for the **Overview** document type that introduces a given Kyma component.
 >
 >  In the document:
 > * Describe the component in general.

--- a/guidelines/templates/resources/overview.md
+++ b/guidelines/templates/resources/overview.md
@@ -11,7 +11,7 @@ type: Overview
 > * Describe the component in general.
 > * Provide its purpose and function.
 > * Be short but descriptive.
-> * Avoid headings.
+> * Avoid headings. If you want to provide more details, create a separate **Details** document.
 > * Follow the `{000}-overview-{component-name}.md` convention to name it.
 >
 > For reference, see the existing **Overview** document for the [Application Connector](https://github.com/kyma-project/kyma/blob/master/docs/application-connector/docs/001-overview-application-connector.md).

--- a/guidelines/templates/resources/overview.md
+++ b/guidelines/templates/resources/overview.md
@@ -12,6 +12,6 @@ type: Overview
 > * Provide its purpose and function.
 > * Be short but descriptive.
 > * Avoid headings. If you want to provide more details, create a separate **Details** document.
-> * Follow the `{000}-overview-{component-name}.md` convention to name it.
+> * Follow the `{000}-overview-{component-name}.md` convention to name it. 
 >
 > For reference, see the existing **Overview** document for the [Application Connector](https://github.com/kyma-project/kyma/blob/master/docs/application-connector/docs/001-overview-application-connector.md).


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Added a template for the **Overview** type of document
- Updated the `README.md` with the template list
- Added the link to the template in the `content-strategy.md` document
- Fixed minor issues in the existing templates

**Related issue(s)**

Resolves #31 