### PR TITLE
Prepare a template for Architecture document

### DIFF
--- a/guidelines/content-guidelines/content-strategy.md
+++ b/guidelines/content-guidelines/content-strategy.md
@@ -44,7 +44,7 @@ Each technical topic must have the following document types:
 >**NOTE:** The Kyma content developers create templates for a given document type once there are at least two documents to use as a base for such a template.
 
 * [Overview](../templates/resources/overview.md) - Use it to describe the component in general. It serves as an entry point for the topic. Make sure it is short but descriptive.
-* **Architecture** - Use it to describe in detail the architecture of the component. Include a diagram in this document.
+* [Architecture](../templates/resources/architecture.md) - Use it to describe in detail the architecture of the component. Include a diagram in this document.
 * **Getting Started** - Use it to provide a clear step-by-step instruction that helps the user to understand a given concept better. The user must be able to go through all the steps of the document and complete them. There is no separate tutorial type. The document does not have to explicitly point out the example used as, at the end, the explicit reference to the example will be in the main content of the guide.
 * [Details](../templates/resources/details.md) - Use it to describe more technical details of the component that do not fit into any other document type. Among other things, include a detailed explanation of the application lifecycle that describes how the resource is created and what other resources are created, how it is updated, how it is removed, and what each operation means from the technical point of view.
 * **Configuration** - Use it to describe configuration options for a given component. Define the settings that a user can change and the expected outcome of such changes. Include the table structure with the settings in the document.

--- a/guidelines/templates/README.md
+++ b/guidelines/templates/README.md
@@ -18,6 +18,7 @@ The table provides an overview of the template names, the repository they refer 
 | No specific repository | [`Kyma-branded presentation template`](./resources/Kyma_presentation_template.pptx) | Use the official Kyma-branded presentation to talk about the project and present it to new audiences. |
 | [`kyma/docs`](https://github.com/kyma-project/kyma/tree/master/docs) | [`overview.md`](./resources/overview.md) | Use the template to introduce a Kyma component. |
 | [`kyma/docs`](https://github.com/kyma-project/kyma/tree/master/docs) | [`details.md`](./resources/details.md) | Use the template to provide more details about a Kyma component. |
+| [`kyma/docs`](https://github.com/kyma-project/kyma/tree/master/docs) | [`architecture.md`](./resources/architecture.md) | Use the template to describe an architecture of a Kyma component. |
 | [`community/sig-and-wg`](https://github.com/kyma-project/community/sig-and-wg) | [`DR.md`](./resources/DR.md) | Use the template to document decisions made by SIGs and WGs.
 | [`community/sig-and-wg`](https://github.com/kyma-project/community/sig-and-wg) | [`sig-wg-readme-template.md`](./resources/sig-wg-readme-template.md) | Use the template for the main `README.md` document in a given SIG or WG folder.
 | [`community/sig-and-wg`](https://github.com/kyma-project/community/sig-and-wg) | [`sig-wg-meeting-notes-template.md`](./resources/sig-wg-meeting-notes-template.md) | Use the template to document meeting notes of a given SIG or WG.

--- a/guidelines/templates/README.md
+++ b/guidelines/templates/README.md
@@ -18,7 +18,7 @@ The table provides an overview of the template names, the repository they refer 
 | No specific repository | [`Kyma-branded presentation template`](./resources/Kyma_presentation_template.pptx) | Use the official Kyma-branded presentation to talk about the project and present it to new audiences. |
 | [`kyma/docs`](https://github.com/kyma-project/kyma/tree/master/docs) | [`overview.md`](./resources/overview.md) | Use the template to introduce a Kyma component. |
 | [`kyma/docs`](https://github.com/kyma-project/kyma/tree/master/docs) | [`details.md`](./resources/details.md) | Use the template to provide more details about a Kyma component. |
-| [`kyma/docs`](https://github.com/kyma-project/kyma/tree/master/docs) | [`architecture.md`](./resources/architecture.md) | Use the template to describe an architecture of a Kyma component. |
+| [`kyma/docs`](https://github.com/kyma-project/kyma/tree/master/docs) | [`architecture.md`](./resources/architecture.md) | Use the template to describe the architecture of a Kyma component. |
 | [`community/sig-and-wg`](https://github.com/kyma-project/community/sig-and-wg) | [`DR.md`](./resources/DR.md) | Use the template to document decisions made by SIGs and WGs.
 | [`community/sig-and-wg`](https://github.com/kyma-project/community/sig-and-wg) | [`sig-wg-readme-template.md`](./resources/sig-wg-readme-template.md) | Use the template for the main `README.md` document in a given SIG or WG folder.
 | [`community/sig-and-wg`](https://github.com/kyma-project/community/sig-and-wg) | [`sig-wg-meeting-notes-template.md`](./resources/sig-wg-meeting-notes-template.md) | Use the template to document meeting notes of a given SIG or WG.

--- a/guidelines/templates/resources/architecture.md
+++ b/guidelines/templates/resources/architecture.md
@@ -1,0 +1,15 @@
+---
+title: {Component} architecture
+type: Architecture
+---
+
+>**NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
+>
+>This is a template for the **Architecture** document type that describes in detail the architecture of the given Kyma component.
+>
+>  In the document:
+> * Provide a [diagram](../../content-guidelines/diagrams.md) which describes the workflow of a given component.
+> * Describe in details the steps of the workflow and all components involved in the process.
+> * Follow the `{000}-architecture-{component}.md` convention to name the document. The title must summarize the general concept of what the document is about.
+>
+> For reference, see the existing **Architecture** document for the [Remote Environment Broker](https://github.com/kyma-project/kyma/blob/master/docs/service-brokers/docs/020-architecture-reb.md).

--- a/guidelines/templates/resources/architecture.md
+++ b/guidelines/templates/resources/architecture.md
@@ -3,14 +3,16 @@ title: Architecture
 type: Architecture
 ---
 
->**NOTE:** In case there are more than one Architecture documents in a repository, follow this convention for a title: `{Component name} architecture`.
-
 >**NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
 >
->This is a template for the **Architecture** document type that describes in detail the architecture of the given Kyma component. This document should include, among others, all components involved in the workflow, a description of the functions they perform in the workflow, and a step-by-step description of the workflow itself.
+>This is a template for the **Architecture** document type that describes in detail the architecture of a given Kyma component. This document should include, among others, the diagram which illustrates all components and sub-components involved, a description of the functions they perform, and a step-by-step description of the workflow.
 >
 >  In the document:
-> * Provide a [diagram](../../content-guidelines/diagrams.md) which illustrates the workflow of a given component.
-> * Follow the `{000}-architecture-{component}.md` convention to name the document. The title must summarize the general concept of what the document is about.
+> * Provide a [diagram](../../content-guidelines/diagrams.md) which illustrates the workflow of a given component. The diagram is a **mandatory** element of this document.
+> * Describe all components and sub-components involved in the workflow together with their functions.
+> * Use an ordered list to describe a step-by-step workflow.
+> * Use sections if the document does not describe any workflow but the overall arrangement of the components and sub-components. In this case, each component should be described in a separate section. Use H2 (##) for sections and H3 (###) for sub-sections. Do not use headings smaller than H3 as they do not display well on the UI.
+> * Follow the `{000}-architecture-{component}.md` convention to name the document.
+> * In the metadata section, follow the `{Component name} architecture` convention for the `title` in case there are more than one Architecture document in a repository. If there is only one document of a certain type, remove the `type` metadata completely so that the document displays well on the UI.
 >
 > For reference, see the existing **Architecture** document for the [Remote Environment Broker](https://github.com/kyma-project/kyma/blob/master/docs/service-brokers/docs/020-architecture-reb.md).

--- a/guidelines/templates/resources/architecture.md
+++ b/guidelines/templates/resources/architecture.md
@@ -13,6 +13,6 @@ type: Architecture
 > * Use an ordered list to describe a step-by-step workflow.
 > * Use sections if the document does not describe any workflow but the overall arrangement of the components and sub-components. In this case, each component should be described in a separate section. Use H2 (##) for sections and H3 (###) for sub-sections. Do not use headings smaller than H3 as they do not display well on the UI.
 > * Follow the `{000}-architecture-{component}.md` convention to name the document.
-> * In the metadata section, follow the `{Component name} architecture` convention for the `title` in case there are more than one Architecture document in a repository. If there is only one document of a certain type, remove the `type` metadata completely so that the document displays well on the UI.
+> * In the metadata section, follow the `{Component name} architecture` convention for the `title` if there are more than one Architecture document in a repository. If there is only one document of a certain type, remove the `type` metadata completely so that the document displays well on the UI.
 >
 > For reference, see the existing **Architecture** document for the [Remote Environment Broker](https://github.com/kyma-project/kyma/blob/master/docs/service-brokers/docs/020-architecture-reb.md).

--- a/guidelines/templates/resources/architecture.md
+++ b/guidelines/templates/resources/architecture.md
@@ -1,7 +1,9 @@
 ---
-title: {Component} architecture
+title: Architecture
 type: Architecture
 ---
+
+>**NOTE:** In case there are more than one Architecture documents in a repository, follow this convention for a title: `{Component name} architecture`.
 
 >**NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
 >

--- a/guidelines/templates/resources/architecture.md
+++ b/guidelines/templates/resources/architecture.md
@@ -5,11 +5,10 @@ type: Architecture
 
 >**NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
 >
->This is a template for the **Architecture** document type that describes in detail the architecture of the given Kyma component.
+>This is a template for the **Architecture** document type that describes in detail the architecture of the given Kyma component. This document should include, among others, all components involved in the workflow, a description of the functions they perform in the workflow, and a step-by-step description of the workflow itself.
 >
 >  In the document:
-> * Provide a [diagram](../../content-guidelines/diagrams.md) which describes the workflow of a given component.
-> * Describe in details the steps of the workflow and all components involved in the process.
+> * Provide a [diagram](../../content-guidelines/diagrams.md) which illustrates the workflow of a given component.
 > * Follow the `{000}-architecture-{component}.md` convention to name the document. The title must summarize the general concept of what the document is about.
 >
 > For reference, see the existing **Architecture** document for the [Remote Environment Broker](https://github.com/kyma-project/kyma/blob/master/docs/service-brokers/docs/020-architecture-reb.md).

--- a/guidelines/templates/resources/custom-resource.md
+++ b/guidelines/templates/resources/custom-resource.md
@@ -6,7 +6,7 @@ type: Custom Resource
 > **NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
 >
 > This document is a ready-to-use template for a custom resource (CR) document type that provides a sample custom resource and description of its elements. Additionally, the document points to the Custom Resource Definition (CRD) used to create CRs of the given kind. Follow the `{000}-{CRD-kind}-custom-resource.md` convention to name the document.
-For reference, see the existing documents for the [Installation](https://github.com/kyma-project/kyma/blob/master/docs/kyma/docs/040-installation-custom-resource.md) and the [Api](https://github.com/kyma-project/kyma/blob/master/docs/api-gateway/docs/011-api-custom-resource.md) CRs.
+For reference, see the existing documents for the [Installation](https://github.com/kyma-project/kyma/blob/master/docs/kyma/docs/040-cr-installation.md) and the [Api](https://github.com/kyma-project/kyma/blob/master/docs/api-gateway/docs/011-cr-api.md) CRs.
 
 The {CRD name} Custom Resource Definition (CRD) is a detailed description of the kind of data and the format used to {provide the CRD description}. To get the up-to-date CRD and show the output in the yaml format, run this command:
 

--- a/guidelines/templates/resources/overview.md
+++ b/guidelines/templates/resources/overview.md
@@ -3,6 +3,8 @@ title: Overview
 type: Overview
 ---
 
+>**NOTE:** In case there are more than one Overview documents in a repository, follow this convention for a title: `{Component name} overview`.
+
 >**NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
 >
 > This is a template for the **Overview** document type that introduces a given Kyma component.
@@ -12,6 +14,6 @@ type: Overview
 > * Provide its purpose and function.
 > * Be short but descriptive.
 > * Avoid headings. If you want to provide more details, create a separate **Details** document.
-> * Follow the `{000}-overview-{component-name}.md` convention to name it. 
+> * Follow the `{000}-overview-{component-name}.md` convention to name it.
 >
 > For reference, see the existing **Overview** document for the [Application Connector](https://github.com/kyma-project/kyma/blob/master/docs/application-connector/docs/001-overview-application-connector.md).

--- a/sig-and-wg/sig-core/proposals/authorization-proxy.md
+++ b/sig-and-wg/sig-core/proposals/authorization-proxy.md
@@ -16,12 +16,12 @@ It is not possible to install the Kyma project on the managed clusters such as G
 2. Kyma depends on some alpha features of Kubernetes that are not supported by the managed clusters, for example PodPreset from `settings.k8s.io/v1alpha1`. Other apiserver configuration entries required by kyma, that might be missing in managed clusters:
     - admission plugins: Initializers, NamespaceLifecycle, LimitRanger, ServiceAccount, MutatingAdmissionWebhook, ValidatingAdmissionWebhook, DefaultStorageClass, ResourceQuota, PodPreset
     - alfa APIs : batch/v2alpha1, settings.k8s.io/v1alpha1, admissionregistration.k8s.io/v1alpha1
-    
+
 ## Proposal
 
-### OIDC configuration 
+### OIDC configuration
 
->**NOTE:** Read [this](https://github.com/kyma-project/kyma/blob/master/docs/authorization-and-authentication/docs/003-architecture.md) document first to understand the current authorization concept.
+>**NOTE:** Read [this](https://github.com/kyma-project/kyma/blob/master/docs/authorization-and-authentication/docs/003-architecture-auth.md) document first to understand the current authorization concept.
 
 The idea is to move the responsibility for authorization from the kube-apiserver to the Authorization Proxy. If the Authorization Proxy verifies user permissions, it is not required to configure OpenID Connect tokens in the kube-apiserver. The proxy can use a service account to communicate with the apiserver. The request flow would be as follows:
 - The proxy validates JWT passed in the Authorization Bearer header.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add a template for the Architecture document type.
- Update the table in the README document that lists all the templates.
- Provide the link to the template in the "Content strategy" document.
- Update the "Overview" document.
- Update links (kyma #835)

**Related issue(s)**
#29 
