### PR TITLE
Add the info about naming the metadata to the templates

### DIFF
--- a/guidelines/templates/resources/cli-reference.md
+++ b/guidelines/templates/resources/cli-reference.md
@@ -1,6 +1,5 @@
 ---
 title: CLI reference
-type: CLI reference
 ---
 
 >**NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.

--- a/guidelines/templates/resources/custom-resource.md
+++ b/guidelines/templates/resources/custom-resource.md
@@ -5,7 +5,7 @@ type: Custom Resource
 
 > **NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
 >
-> This document is a ready-to-use template for a custom resource (CR) document type that provides a sample custom resource and description of its elements. Additionally, the document points to the Custom Resource Definition (CRD) used to create CRs of the given kind. Follow the `{000}-{CRD-kind}-custom-resource.md` convention to name the document.
+> This document is a ready-to-use template for a custom resource (CR) document type that provides a sample custom resource and description of its elements. Additionally, the document points to the Custom Resource Definition (CRD) used to create CRs of the given kind. Follow the `{000}-cr-{CRD-kind}.md` convention to name the document. If there is only one document of a certain type, remove the `type` metadata completely so that the document displays well on the UI.
 For reference, see the existing documents for the [Installation](https://github.com/kyma-project/kyma/blob/master/docs/kyma/docs/040-cr-installation.md) and the [Api](https://github.com/kyma-project/kyma/blob/master/docs/api-gateway/docs/011-cr-api.md) CRs.
 
 The {CRD name} Custom Resource Definition (CRD) is a detailed description of the kind of data and the format used to {provide the CRD description}. To get the up-to-date CRD and show the output in the yaml format, run this command:

--- a/guidelines/templates/resources/details.md
+++ b/guidelines/templates/resources/details.md
@@ -13,6 +13,7 @@ type: Details
 > * Use headings to name sections. Use H2 (##) for the main sections and H3 (###) for the sub-sections. Do not use headings smaller than H3 as they do not display well.
 > * Provide any relevant links to the related external documentation. However, do not use cross-references between documents in the `kyma/docs` folder. Mention the related document title instead and put the document name in bold.
 > * Do not mix different concepts in one document. Instead, describe them in separate documents.
-> * Follow the `{000}-details-{document-title}.md` convention to name the document. The title must summarize the general concept of what the document is about.
+> * Follow the `{000}-details-{document-title}.md` convention to name the document. The title must summarize what the document is about.
+> * If there is only one document of a certain type, remove the `type` metadata completely so that the document displays well on the UI.
 >
 > For reference, see the existing **Details** document concerning the [Application Connector security](https://github.com/kyma-project/kyma/blob/master/docs/application-connector/docs/011-details-ac-security.md).

--- a/guidelines/templates/resources/overview.md
+++ b/guidelines/templates/resources/overview.md
@@ -14,6 +14,7 @@ type: Overview
 > * Provide its purpose and function.
 > * Be short but descriptive.
 > * Avoid headings. If you want to provide more details, create a separate **Details** document.
-> * Follow the `{000}-overview-{component-name}.md` convention to name it.
+> * Follow the `{000}-overview-{component-name}.md` convention to name the document.
+> * In the metadata section, follow the `{Component name} overview` convention for the `title` if there are more than one Overview document in a repository. If there is only one document of a certain type, remove the `type` metadata completely so that the document displays well on the UI.
 >
 > For reference, see the existing **Overview** document for the [Application Connector](https://github.com/kyma-project/kyma/blob/master/docs/application-connector/docs/001-overview-application-connector.md).


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add information that the "type" section in the metadata section should be removed if there is only one document of a given type in the repository so that it displays well on the UI.
- Update the templates

