### PR TITLE
Update the decision record template

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -52,7 +52,7 @@ The SIG/WG decison-making process looks as follows:
 
 1. Every decision starts with creating a PR with the [**Decision Record**](./guidelines/templates/resources/DR.md) (DR) document that provides the decision details, timelines, status, the related context, and associated consequences. The DR can reference a proposal or any other related document.
 
-> **NOTE:** The Decision Record does not need to be created in the case when few proposals need a single decison. In that case add link of a new proposal to the existing Decision Record. 
+> **NOTE:** If a few proposals need a single decision, create only one Decision Record and update it with links to all related proposals. 
 
 2. The PR creator sends the table with the decision log details to the related SIG/WG mailing list. If the decision input providers are not part of the mailing list, add them to the email communication.
 3. The discussion on the proposed decision can happen through the mailing list, on the related Slack channel, or directly on the PR. You can also add the topic to the agenda of the upcoming SIG/WG meeting and discuss it with the SIG/WG members. Encourage the discussion and bring up any objections early in the process. A person with a different approach to the topic can create a counter proposal.
@@ -61,4 +61,4 @@ The SIG/WG decison-making process looks as follows:
 6. If there are still unresolved objections by the decision due date, merge the PR with the `Proposed` status. The ultimate decision makers defined in the decision log table make the final decision.
 7. After the final decision, update the decision log to either `Accepted` or `Declined`.
 
->**NOTE:** Only the ultimate decision makers can request to revisit the decision before the revision date. To do it, raise an issue in the `community` repository with all details and the reason why you want to discuss the decision earlier than agreed. 
+>**NOTE:** Only the ultimate decision makers can request to revisit the decision before the revision date. To do it, raise an issue in the `community` repository with all details and the reason why you want to discuss the decision earlier than agreed.

--- a/guidelines/templates/resources/DR.md
+++ b/guidelines/templates/resources/DR.md
@@ -14,7 +14,7 @@ Created on {YYYY-MM-DD} by {name and surname (@Github username)}.
 | Input provider(s) | {Include those who influence the decision and, if possible, those whom the decision affects.} |
 | Group(s) affected by the decision | {Specify whom the decision affects.} |
 | Decision type | {Type in `Binary`, `Choice`, or `Prioritization`. The `Binary` type refers to the  yes/no decisions, the `Choice` type means that the decision involves choosing between many possibilities, such as a name for a new product, and the `Prioritization` type involves ranking a number of options, such as choosing the next five features to build out of one hundred possible options.} |
-| Earliest date to revisit the decision | {Specify the date from which the SIG/WG members can revisit the decision. Use the `YYYY-MM-DD` date format. Only the ultimate decision makers can request to revisit the decision before that date. In both cases, revisiting the decision starts with raising an issue.} |
+| Earliest date to revisit the decision | {Specify the date from which the SIG/WG members can raise an issue to revisit the decision. Use the `YYYY-MM-DD` date format. The date does not apply to ultimate decision makers who can raise an issue to revisit the decision anytime.} |
 
 ## Context
 

--- a/guidelines/templates/resources/DR.md
+++ b/guidelines/templates/resources/DR.md
@@ -14,7 +14,7 @@ Created on {YYYY-MM-DD} by {name and surname (@Github username)}.
 | Input provider(s) | {Include those who influence the decision and, if possible, those whom the decision affects.} |
 | Group(s) affected by the decision | {Specify whom the decision affects.} |
 | Decision type | {Type in `Binary`, `Choice`, or `Prioritization`. The `Binary` type refers to the  yes/no decisions, the `Choice` type means that the decision involves choosing between many possibilities, such as a name for a new product, and the `Prioritization` type involves ranking a number of options, such as choosing the next five features to build out of one hundred possible options.} |
-| Earliest date to revisit the decision | {Specify the date from which the SIG/WG members can revisit the decision. Use the `YYYY-MM-DD` date format.} |
+| Earliest date to revisit the decision | {Specify the date from which the SIG/WG members can revisit the decision. Use the `YYYY-MM-DD` date format. Only the ultimate decision makers can request to revisit the decision before that date. In both cases, revisiting the decision starts with raising an issue.} |
 
 ## Context
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Updated the `DR.md` template to mention who (and how) can revisit the decision before the revision date.
- Corrected the note in the `governance.md` document.

**Related issue(s)**
See also #64 
