### PR TITLE
Update the guidelines to include information on obligatory labels in PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,22 +57,24 @@ To contribute code or content to a given Kyma repository, follow these steps:
 
 1. Make sure that the change is valid and approved. If you are an external contributor, **open a GitHub issue** before you make a contribution.
 2. Fork the Kyma repository that you want to contribute to.
-3. Clone it locally, add a remote upstream repository for the original repository, and set up the `master` branch to track the remote `master` branch from the upstream repository. See the [git-workflow](git-workflow.md) document for details on fork configuration.
+3. Clone it locally, add a remote upstream repository for the original repository, and set up the `master` branch to track the remote `master` branch from the upstream repository. See the [git-workflow](git-workflow.md) document for steps to configure your fork.
 4. Create a new branch out of the local `master` branch of the forked repository.
-5. Commit and push changes on your new branch. Create a clear and descriptive final commit message in which you specify what you have changed.
+5. Commit and push changes on your new branch. Create a clear and descriptive commit message in which you specify what you have changed. See the [`git-workflow.md`](./git-workflow.md) document for commit message guidelines.
 6. Create a pull request from your branch on the forked repository to the `master` branch of the original, upstream repository. Fill in the pull request template according to instructions.
 7. Read and accept the Contributor Licence Agreement (CLA).
 8. If there are merge conflicts on your pull request, squash your commits and rebase the `master` branch.
-9. On the pull request, select the [**Allow edits from maintainers**](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option to allow upstream repository maintainers and those with the push access to the upstream repository, to commit to your forked branch.
-10. If your change relates to any existing GitHub issue, provide a link to it in your pull request.
-11. Run the relevant CI job manually. If you are an external contributor, contact the repository maintainers specified in the `CODEOWNERS` file to do it for you.
-12. Wait for the Kyma maintainers to review and approve your pull request. The maintainers can approve it, request enhancements to your change, or reject it.
+9. In your pull request:
+
+- Provide a reference to any related GitHub issue.
+- Select the [**Allow edits from maintainers**](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option to allow upstream repository maintainers and those with the push access to the upstream repository, to commit to your forked branch.
+- Add at least one `area/{capability}` label to your pull request to categorize changes you made. Labels group pull requests collected in the `CHANGELOG.md` file.
+
+10. Run the relevant CI job manually. If you are an external contributor, contact the repository maintainers specified in the `CODEOWNERS` file to do it for you.
+11. Wait for the Kyma maintainers to review and approve your pull request. The maintainers can approve it, request enhancements to your change, or reject it.
 
 > **NOTE:** The reviewer must check if the related CI job and tests have completed successfully before approving the pull request.
 
 13. When the maintainers approve your change, merge the pull request. If you are an external contributor, contact the repository maintainers specified in the `CODEOWNERS` file to do the merge.
-
-Read the [git-workflow](git-workflow.md) document. It describes the Kyma contribution workflow that relies on forks, branches, rebasing, and squashing. The document also contains guidelines for writing commit messages.
 
 ### Report an issue
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ To contribute code or content to a given Kyma repository, follow these steps:
 9. In your pull request:
 
 - Provide a reference to any related GitHub issue.
-- Select the [**Allow edits from maintainers**](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option to allow upstream repository maintainers and those with the push access to the upstream repository, to commit to your forked branch.
+- Make sure that the [**Allow edits from maintainers**](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option is selected to allow upstream repository maintainers, and those with the push access to the upstream repository, to commit to your forked branch.
 - Choose at least one `area/{capability}` label from the available list and add it to your pull request to categorize changes you made. Labels are required to include your pull request in the `CHANGELOG.md` file and group it accordingly.
 
 10. Run the relevant CI job manually. If you are an external contributor, contact the repository maintainers specified in the `CODEOWNERS` file to do it for you.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ To contribute code or content to a given Kyma repository, follow these steps:
 
 - Provide a reference to any related GitHub issue.
 - Select the [**Allow edits from maintainers**](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option to allow upstream repository maintainers and those with the push access to the upstream repository, to commit to your forked branch.
-- Add at least one `area/{capability}` label to your pull request to categorize changes you made. Labels group pull requests collected in the `CHANGELOG.md` file.
+- Choose at least one `area/{capability}` label from the available list and add it to your pull request to categorize changes you made. Labels are required to include your pull request in the `CHANGELOG.md` file and group it accordingly.
 
 10. Run the relevant CI job manually. If you are an external contributor, contact the repository maintainers specified in the `CODEOWNERS` file to do it for you.
 11. Wait for the Kyma maintainers to review and approve your pull request. The maintainers can approve it, request enhancements to your change, or reject it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,18 +57,16 @@ To contribute code or content to a given Kyma repository, follow these steps:
 
 1. Make sure that the change is valid and approved. If you are an external contributor, **open a GitHub issue** before you make a contribution.
 2. Fork the Kyma repository that you want to contribute to.
-3. Clone it locally, add a remote upstream repository for the original repository, and set up the `master` branch to track the remote `master` branch from the upstream repository. See the [git-workflow](git-workflow.md) document for steps to configure your fork.
+3. Clone it locally, add a remote upstream repository for the original repository, and set up the `master` branch to track the remote `master` branch from the upstream repository. See the [git-workflow](git-workflow.md) document to learn how to configure your fork.
 4. Create a new branch out of the local `master` branch of the forked repository.
-5. Commit and push changes on your new branch. Create a clear and descriptive commit message in which you specify what you have changed. See the [`git-workflow.md`](./git-workflow.md) document for commit message guidelines.
+5. Commit and push changes to your new branch. Create a clear and descriptive commit message in which you specify what you have changed. See the [`git-workflow.md`](./git-workflow.md) document for commit message guidelines.
 6. Create a pull request from your branch on the forked repository to the `master` branch of the original, upstream repository. Fill in the pull request template according to instructions.
 7. Read and accept the Contributor Licence Agreement (CLA).
 8. If there are merge conflicts on your pull request, squash your commits and rebase the `master` branch.
 9. In your pull request:
-
 - Provide a reference to any related GitHub issue.
 - Make sure that the [**Allow edits from maintainers**](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option is selected to allow upstream repository maintainers, and those with the push access to the upstream repository, to commit to your forked branch.
-- Choose at least one `area/{capability}` label from the available list and add it to your pull request to categorize changes you made. Labels are required to include your pull request in the `CHANGELOG.md` file and group it accordingly.
-
+- Choose at least one `area/{capability}` label from the available list and add it to your pull request to categorize changes you made. Labels are required to include your pull request in the `CHANGELOG.md` file, and classify it accordingly.
 10. Run the relevant CI job manually. If you are an external contributor, contact the repository maintainers specified in the `CODEOWNERS` file to do it for you.
 11. Wait for the Kyma maintainers to review and approve your pull request. The maintainers can approve it, request enhancements to your change, or reject it.
 

--- a/git-workflow.md
+++ b/git-workflow.md
@@ -130,26 +130,28 @@ Use the `git push` command to push any further commits made on your local branch
 
 Create a pull request from the branch of your forked repository to the `master` branch of the upstream repository and wait for the maintainers' review.
 
-> **NOTE:** On the pull request, select the [**Allow edits from maintainers**](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option to allow upstream repository maintainers and users with push access to the upstream repository to commit to your forked branch.
+In each pull request:
 
-In each pull request, include a description or a reference to a detailed description of the steps that the maintainer goes through to check if the pull request works and does not break any other functionality.
+- Include a description or a reference to a detailed description of the steps that the maintainer goes through to check if the pull request works and does not break any other functionality.
 
-Subject line:
-- Include a short description of changes made.
-- Limit the line to 50 characters.
-- Capitalize it.
-- Do not end the subject line with a period.
-- Use the imperative mood.
-- Separate it from the body with a blank line.
+  Subject line:
+  - Include a short description of changes made.
+  - Use the imperative mood.
+  - Limit the line to 50 characters.
+  - Capitalize it.
+  - Do not end the subject line with a period.
 
-Pull request body:
-- If you made multiple changes and the changes refer to different files, provide more details in the commit body.
-- Wrap each body line at 72 characters.
-- Use the body to explain what and why, rather than how.
-- List any side effects or other unintuitive consequences of this change.
-- Separate paragraphs with blank lines.
-- Use bullet points for a list of items.
-- Put references to any related issues at the end. For example, `Resolves #123`, `Fixes #43`, or `See also #33`.
+  Pull request body:
+  - If you made multiple changes and the changes refer to different files, provide details in the pull request body.
+  - Use the body to explain what and why, rather than how.
+  - Use bullet points for a list of items.
+  - List any side effects or other unintuitive consequences of this change.
+
+- Put references to any related issues at the end of the pull request body. For example, write `Resolves #123`, `Fixes #43`, or `See also #33`.
+
+- Select the [**Allow edits from maintainers**](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option to allow upstream repository maintainers and users with push access to the upstream repository to commit to your forked branch.
+
+- Add at least one `area/{capability}` label to your pull request to categorize changes you made. Labels group pull requests collected in the `CHANGELOG.md` file.
 
 > **NOTE:** Steps 5 and 6 are optional. Follow them if you have merge conflicts on your pull request.
 

--- a/git-workflow.md
+++ b/git-workflow.md
@@ -149,7 +149,7 @@ In each pull request:
 
 - Put references to any related issues at the end of the pull request body. For example, write `Resolves #123`, `Fixes #43`, or `See also #33`.
 - Make sure that the [**Allow edits from maintainers**](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option is selected to allow upstream repository maintainers, and users with push access to the upstream repository, to commit to your forked branch.
-- Choose at least one `area/{capability}` label from the available list and add it to your pull request to categorize changes you made. Labels are required to include your pull request in the `CHANGELOG.md` file and group it accordingly.
+- Choose at least one `area/{capability}` label from the available list and add it to your pull request to categorize changes you made. Labels are required to include your pull request in the `CHANGELOG.md` file, and classify it accordingly.
 
 > **NOTE:** Steps 5 and 6 are optional. Follow them if you have merge conflicts on your pull request.
 

--- a/git-workflow.md
+++ b/git-workflow.md
@@ -148,10 +148,8 @@ In each pull request:
   - List any side effects or other unintuitive consequences of this change.
 
 - Put references to any related issues at the end of the pull request body. For example, write `Resolves #123`, `Fixes #43`, or `See also #33`.
-
 - Select the [**Allow edits from maintainers**](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option to allow upstream repository maintainers and users with push access to the upstream repository to commit to your forked branch.
-
-- Add at least one `area/{capability}` label to your pull request to categorize changes you made. Labels group pull requests collected in the `CHANGELOG.md` file.
+- Choose at least one `area/{capability}` label from the available list and add it to your pull request to categorize changes you made. Labels are required to include your pull request in the `CHANGELOG.md` file and group it accordingly.
 
 > **NOTE:** Steps 5 and 6 are optional. Follow them if you have merge conflicts on your pull request.
 

--- a/git-workflow.md
+++ b/git-workflow.md
@@ -148,7 +148,7 @@ In each pull request:
   - List any side effects or other unintuitive consequences of this change.
 
 - Put references to any related issues at the end of the pull request body. For example, write `Resolves #123`, `Fixes #43`, or `See also #33`.
-- Select the [**Allow edits from maintainers**](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option to allow upstream repository maintainers and users with push access to the upstream repository to commit to your forked branch.
+- Make sure that the [**Allow edits from maintainers**](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option is selected to allow upstream repository maintainers, and users with push access to the upstream repository, to commit to your forked branch.
 - Choose at least one `area/{capability}` label from the available list and add it to your pull request to categorize changes you made. Labels are required to include your pull request in the `CHANGELOG.md` file and group it accordingly.
 
 > **NOTE:** Steps 5 and 6 are optional. Follow them if you have merge conflicts on your pull request.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Updated the `git-workflow.md` and `CONTRIBUTING.md` documents with information on the obligation to add at least `area/{capability}` label to each pull request.

**Related issue(s)**
See also #93 .
