### PR TITLE
Add the size subsection

### DIFF
--- a/guidelines/content-guidelines/diagrams.md
+++ b/guidelines/content-guidelines/diagrams.md
@@ -17,7 +17,7 @@ Use [draw.io](https://www.draw.io) as a recommended tool. Export the diagram as 
 
 Keep your diagram reasonable in size. Preview the image at full size to see how it fits into the whole document. The diagram should be large enough to be legible and convey the intended message, but should not overthrow the whole document. To demonstrate large concepts, simplify the diagram or divide it into a few smaller ones.
 
->**NOTE:** The diagrams keep its original aspect ratio both on the Console UI and on the `kyma-project.io` website. The only resizing is done on the website with the maximum width of the diagram set to 860px.
+>**NOTE:** The diagrams keep their original aspect ratio both on the Console UI and on the `kyma-project.io` website. The only resizing is done on the website with the maximum width of the diagram set to 860px.
 
 ## Background
 

--- a/guidelines/content-guidelines/diagrams.md
+++ b/guidelines/content-guidelines/diagrams.md
@@ -15,9 +15,9 @@ Use [draw.io](https://www.draw.io) as a recommended tool. Export the diagram as 
 
 ## Size
 
-Keep your diagram reasonable in size. Preview the image at full size to see how it fits into the whole document. The diagram should be large enough to be legible and convey the intended message, but should not overthrow the whole document. To demonstrate large concepts, simplify the diagram or divide it into a few smaller ones.
+Keep your diagram reasonable in size. Preview the image at full size to see how it fits into the whole document. The diagram should be large enough to be legible and convey the intended message, but should not dominate the whole document. To demonstrate large concepts, simplify the diagram or divide it into a few smaller ones.
 
->**NOTE:** The diagrams keep their original aspect ratio both on the Console UI and on the `kyma-project.io` website. The only resizing is done on the website with the maximum width of the diagram set to 860px.
+>**NOTE:** The diagrams keep their original aspect ratio on both the Console UI and the `kyma-project.io` website. However, the maximum diagram width on the website is 860px. Any diagram that exceeds that limit is resized to the maximum width. 
 
 ## Background
 

--- a/guidelines/content-guidelines/diagrams.md
+++ b/guidelines/content-guidelines/diagrams.md
@@ -17,7 +17,7 @@ Use [draw.io](https://www.draw.io) as a recommended tool. Export the diagram as 
 
 Keep your diagram reasonable in size. Preview the image at full size to see how it fits into the whole document. The diagram should be large enough to be legible and convey the intended message, but should not dominate the whole document. To demonstrate large concepts, simplify the diagram or divide it into a few smaller ones.
 
->**NOTE:** The diagrams keep their original aspect ratio on both the Console UI and the `kyma-project.io` website. However, the maximum diagram width on the website is 860px. Any diagram that exceeds that limit is resized to the maximum width. 
+>**NOTE:** The diagrams keep their original aspect ratio on both the Console UI and the `kyma-project.io` website. However, the maximum width on the website is 860px. Any diagram that exceeds that limit is resized to the maximum width. 
 
 ## Background
 

--- a/guidelines/content-guidelines/diagrams.md
+++ b/guidelines/content-guidelines/diagrams.md
@@ -13,6 +13,12 @@ For details on how to format diagrams and their elements in Kyma documents, see 
 
 Use [draw.io](https://www.draw.io) as a recommended tool. Export the diagram as an SVG and save it under the corresponding `assets` directory.
 
+## Size
+
+Keep your diagram reasonable in size. Preview the image at full size to see how it fits into the whole document. The diagram should be large enough to be legible and convey the intended message, but should not overthrow the whole document. To demonstrate large concepts, simplify the diagram or divide it into a few smaller ones.
+
+>**NOTE:** The `kyma-project.io` website has the maximum width of the image set to 860px.
+
 ## Background
 
 Keep the background of the diagram **white** as it renders well both on Github and in the UI.

--- a/guidelines/content-guidelines/diagrams.md
+++ b/guidelines/content-guidelines/diagrams.md
@@ -17,7 +17,7 @@ Use [draw.io](https://www.draw.io) as a recommended tool. Export the diagram as 
 
 Keep your diagram reasonable in size. Preview the image at full size to see how it fits into the whole document. The diagram should be large enough to be legible and convey the intended message, but should not overthrow the whole document. To demonstrate large concepts, simplify the diagram or divide it into a few smaller ones.
 
->**NOTE:** The `kyma-project.io` website has the maximum width of the image set to 860px.
+>**NOTE:** The diagrams keep its original aspect ratio both on the Console UI and on the `kyma-project.io` website. The only resizing is done on the website with the maximum width of the diagram set to 860px.
 
 ## Background
 

--- a/guidelines/content-guidelines/screenshots.md
+++ b/guidelines/content-guidelines/screenshots.md
@@ -12,11 +12,13 @@ For details on how to format screenshots and their elements in Kyma documents, s
 
 ## Tool
 
-Adjust or capture your screenshots using any tool that outputs high quality images, such as [Snagit](https://www.techsmith.com/screen-capture.html), [Lightshot](https://app.prntscr.com), or [Monosnap](https://www.monosnap.com/welcome). Name the file as `{screenshot-name}` and save it under the corresponding `assets` directory. The desired image format is SVG, but PNG and JPG formats are also acceptable.
+Adjust or capture your screenshots using any tool that outputs high quality images, such as [Snagit](https://www.techsmith.com/screen-capture.html), [Lightshot](https://app.prntscr.com), or [Monosnap](https://www.monosnap.com/welcome). The desired image format is SVG, but PNG and JPG formats are also acceptable.
 Use an online tool such as [TinyPNG](https://tinypng.com/) to compress images and limit the size of each image to 1MB, or smaller.
 If you want to control the size of the image relative to the screen size, use one of these standard percentages: 100%, 75%, 50%, or 25%.
 
 >**NOTE:** The `kyma-project.io` website has the maximum width of the image set to 860px.
+
+Name the file as `{screenshot-name}` and save it under the corresponding `assets` directory.
 
 ## Borders
 

--- a/guidelines/content-guidelines/screenshots.md
+++ b/guidelines/content-guidelines/screenshots.md
@@ -16,7 +16,7 @@ Adjust or capture your screenshots using any tool that outputs high quality imag
 Use an online tool such as [TinyPNG](https://tinypng.com/) to compress images and limit the size of each image to 1MB, or smaller.
 If you want to control the size of the image relative to the screen size, use one of these standard percentages: 100%, 75%, 50%, or 25%.
 
->**NOTE:** The images keep their original aspect ratio both on the Console UI and on the `kyma-project.io` website. The only resizing is done on the website with the maximum width of the image set to 860px.
+>**NOTE:** The images keep their original aspect ratio on both the Console UI and the `kyma-project.io` website. However, the maximum image width on the website is 860px. Any image that exceeds that limit is resized to the maximum width. 
 
 Name the file as `{screenshot-name}` and save it under the corresponding `assets` directory.
 

--- a/guidelines/content-guidelines/screenshots.md
+++ b/guidelines/content-guidelines/screenshots.md
@@ -16,7 +16,7 @@ Adjust or capture your screenshots using any tool that outputs high quality imag
 Use an online tool such as [TinyPNG](https://tinypng.com/) to compress images and limit the size of each image to 1MB, or smaller.
 If you want to control the size of the image relative to the screen size, use one of these standard percentages: 100%, 75%, 50%, or 25%.
 
->**NOTE:** The `kyma-project.io` website has the maximum width of the image set to 860px.
+>**NOTE:** The image keep its original aspect ratio both on the Console UI and on the `kyma-project.io` website. The only resizing is done on the website with the maximum width of the diagram set to 860px.
 
 Name the file as `{screenshot-name}` and save it under the corresponding `assets` directory.
 

--- a/guidelines/content-guidelines/screenshots.md
+++ b/guidelines/content-guidelines/screenshots.md
@@ -16,7 +16,7 @@ Adjust or capture your screenshots using any tool that outputs high quality imag
 Use an online tool such as [TinyPNG](https://tinypng.com/) to compress images and limit the size of each image to 1MB, or smaller.
 If you want to control the size of the image relative to the screen size, use one of these standard percentages: 100%, 75%, 50%, or 25%.
 
->**NOTE:** The images keep their original aspect ratio on both the Console UI and the `kyma-project.io` website. However, the maximum image width on the website is 860px. Any image that exceeds that limit is resized to the maximum width. 
+>**NOTE:** The images keep their original aspect ratio on both the Console UI and the `kyma-project.io` website. However, the maximum width on the website is 860px. Any image that exceeds that limit is resized to the maximum width. 
 
 Name the file as `{screenshot-name}` and save it under the corresponding `assets` directory.
 

--- a/guidelines/content-guidelines/screenshots.md
+++ b/guidelines/content-guidelines/screenshots.md
@@ -16,7 +16,7 @@ Adjust or capture your screenshots using any tool that outputs high quality imag
 Use an online tool such as [TinyPNG](https://tinypng.com/) to compress images and limit the size of each image to 1MB, or smaller.
 If you want to control the size of the image relative to the screen size, use one of these standard percentages: 100%, 75%, 50%, or 25%.
 
->**NOTE:** The image keep its original aspect ratio both on the Console UI and on the `kyma-project.io` website. The only resizing is done on the website with the maximum width of the diagram set to 860px.
+>**NOTE:** The images keep their original aspect ratio both on the Console UI and on the `kyma-project.io` website. The only resizing is done on the website with the maximum width of the image set to 860px.
 
 Name the file as `{screenshot-name}` and save it under the corresponding `assets` directory.
 

--- a/guidelines/content-guidelines/screenshots.md
+++ b/guidelines/content-guidelines/screenshots.md
@@ -16,7 +16,9 @@ Adjust or capture your screenshots using any tool that outputs high quality imag
 Use an online tool such as [TinyPNG](https://tinypng.com/) to compress images and limit the size of each image to 1MB, or smaller.
 If you want to control the size of the image relative to the screen size, use one of these standard percentages: 100%, 75%, 50%, or 25%.
 
-> **NOTE:** Name the file as `{screenshot-name}` and save it under the corresponding `assets` directory.
+>**NOTE:** The `kyma-project.io` website has the maximum width of the image set to 860px.
+
+Name the file as `{screenshot-name}` and save it under the corresponding `assets` directory.
 
 ## Borders
 

--- a/guidelines/content-guidelines/screenshots.md
+++ b/guidelines/content-guidelines/screenshots.md
@@ -12,13 +12,11 @@ For details on how to format screenshots and their elements in Kyma documents, s
 
 ## Tool
 
-Adjust or capture your screenshots using any tool that outputs high quality images, such as [Snagit](https://www.techsmith.com/screen-capture.html), [Lightshot](https://app.prntscr.com), or [Monosnap](https://www.monosnap.com/welcome). The desired image format is SVG, but PNG and JPG formats are also acceptable.
+Adjust or capture your screenshots using any tool that outputs high quality images, such as [Snagit](https://www.techsmith.com/screen-capture.html), [Lightshot](https://app.prntscr.com), or [Monosnap](https://www.monosnap.com/welcome). Name the file as `{screenshot-name}` and save it under the corresponding `assets` directory. The desired image format is SVG, but PNG and JPG formats are also acceptable.
 Use an online tool such as [TinyPNG](https://tinypng.com/) to compress images and limit the size of each image to 1MB, or smaller.
 If you want to control the size of the image relative to the screen size, use one of these standard percentages: 100%, 75%, 50%, or 25%.
 
 >**NOTE:** The `kyma-project.io` website has the maximum width of the image set to 860px.
-
-Name the file as `{screenshot-name}` and save it under the corresponding `assets` directory.
 
 ## Borders
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Added the **Size** subsection to the [`diagrams.md`](https://github.com/kyma-project/community/blob/master/guidelines/content-guidelines/diagrams.md) document 
- Included information on the diagram width limit on the `kyma-project.io` website 
- Added information on website image max sizes to [`screenshots.md`](https://github.com/kyma-project/community/blob/master/guidelines/content-guidelines/screenshots.md)

**Related issue(s)**
See also https://github.com/kyma-project/website/issues/133
