### PR TITLE
Add release notes templates and guidelines

### DIFF
--- a/guidelines/content-guidelines/README.md
+++ b/guidelines/content-guidelines/README.md
@@ -1,0 +1,13 @@
+# Content guidelines
+
+## Overview
+
+
+Content guidelines provide rules and tips for all who contribute content to the Kyma repositories.
+
+Read about:
+
+- The [content strategy](./content-strategy.md) for the Kyma documentation. Learn about the obligatory and optional document types.
+- [Formatting](./formatting-and-style.md), [style and standards](./style-and-standards.md) that apply to the content created throughout the Kyma organization.
+- Rules for creating [diagrams](./diagrams.md) and [screenshots](./screenshots.md).
+- Tips and hints on how to write [release notes](./release-notes.md).

--- a/guidelines/content-guidelines/README.md
+++ b/guidelines/content-guidelines/README.md
@@ -10,3 +10,4 @@ Read about:
 - [Formatting](./formatting-and-style.md), [style, and standards](./style-and-standards.md) that apply to the content created throughout the Kyma organization.
 - Rules for creating [diagrams](./diagrams.md) and [screenshots](./screenshots.md).
 - Tips and hints on how to write [release notes](./release-notes.md).
+- guidelines for making cross-references between the documents in the [kyma/docs](https://github.com/kyma-project/kyma/tree/master/docs) folder.

--- a/guidelines/content-guidelines/README.md
+++ b/guidelines/content-guidelines/README.md
@@ -7,6 +7,6 @@ These guidelines provide rules and tips to all who contribute content to the Kym
 Read about:
 
 - The [content strategy](./content-strategy.md) for the Kyma documentation. Learn about the obligatory and optional document types.
-- [Formatting](./formatting-and-style.md), [style and standards](./style-and-standards.md) that apply to the content created throughout the Kyma organization.
+- [Formatting](./formatting-and-style.md), [style, and standards](./style-and-standards.md) that apply to the content created throughout the Kyma organization.
 - Rules for creating [diagrams](./diagrams.md) and [screenshots](./screenshots.md).
 - Tips and hints on how to write [release notes](./release-notes.md).

--- a/guidelines/content-guidelines/README.md
+++ b/guidelines/content-guidelines/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Content guidelines provide rules and tips for all who contribute content to the Kyma repositories.
+These guidelines provide rules and tips to all who contribute content to the Kyma repositories.
 
 Read about:
 

--- a/guidelines/content-guidelines/README.md
+++ b/guidelines/content-guidelines/README.md
@@ -2,7 +2,6 @@
 
 ## Overview
 
-
 Content guidelines provide rules and tips for all who contribute content to the Kyma repositories.
 
 Read about:

--- a/guidelines/content-guidelines/release-notes.md
+++ b/guidelines/content-guidelines/release-notes.md
@@ -1,0 +1,29 @@
+# Release notes
+Information in release notes must provide readers with everything they need to know to understand the change in the software. A lot of business decisions are made based on the information in release notes. Therefore, always write from the user's perspective, not the developer's perspective. The content of release notes answers the following questions:
+
+* What changed because of this feature or resolved issue?
+* How was the behavior different before this release?
+* Are there changes to the UI?
+* Are there changes to the functionality?
+* Does an error message appear?
+* Was the enhancement based upon customer feedback?
+
+## Prerequisites and requirements
+Because the release notes contain critical information and act as an important communication tool, follow these guidelines so that the documentation is informative and consistent. When authoring release notes, follow the [Style and Standards](./style-and-standards.md) for many agreed-upon standards.
+
+## Headlines
+A headline is short, but interesting, and summarizes your release notes. Write headlines in sentence case.
+
+## Write about new features
+When writing about new features, write an enticing paragraph instead of a short, bulleted list. This is an opportunity to market the new feature to customers from a business perspective.
+
+## Write about resolved issues
+When writing about resolved issues, don't call them bugs. Use the term **resolved issues** because it has a more positive tone. A bulleted list of resolved issues is okay, but ensure that the descriptions make sense.
+
+## Bulleted lists
+For ease of reading, use the same sentence structure throughout a bulleted list. For example, the following items match in sentence structure:
+- Feature xyz - This one is really cool.
+- Feature abc - This one is really, really, cool.
+
+Don't add an entry that doesn't match, such as:
+- Feature JKL: it's not so cool

--- a/guidelines/content-guidelines/release-notes.md
+++ b/guidelines/content-guidelines/release-notes.md
@@ -1,18 +1,18 @@
 # Release notes
 Information in release notes must provide readers with everything they need to know to understand the change in the software. A lot of business decisions are made based on the information in release notes. Therefore, always write from the user's perspective, not the developer's perspective. The content of release notes answers the following questions:
 
-* What changed because of this feature or resolved issue?
+* What has changed because of this feature or resolved issue?
 * How was the behavior different before this release?
 * Are there changes to the UI?
 * Are there changes to the functionality?
 * Does an error message appear?
 * Was the enhancement based upon customer feedback?
 
-## Prerequisites and requirements
+## Guidelines
 Because the release notes contain critical information and act as an important communication tool, follow these guidelines so that the documentation is informative and consistent. When authoring release notes, follow the [Style and Standards](./style-and-standards.md) for many agreed-upon standards.
 
 ## Headlines
-A headline is short, but interesting, and summarizes your release notes. Write headlines in sentence case.
+A headline is short, interesting, and summarizes your release notes. Write headlines in sentence case.
 
 ## Write about new features
 When writing about new features, write an enticing paragraph instead of a short, bulleted list. This is an opportunity to market the new feature to customers from a business perspective.

--- a/guidelines/content-guidelines/release-notes.md
+++ b/guidelines/content-guidelines/release-notes.md
@@ -8,7 +8,6 @@ Information in release notes must provide readers with everything they need to k
 * Does an error message appear?
 * Was the enhancement based upon customer feedback?
 
-## Guidelines
 Because the release notes contain critical information and act as an important communication tool, follow these guidelines so that the documentation is informative and consistent. When authoring release notes, follow the [Style and Standards](./style-and-standards.md) for many agreed-upon standards.
 
 ## Headlines

--- a/guidelines/templates/README.md
+++ b/guidelines/templates/README.md
@@ -24,6 +24,9 @@ The table provides an overview of the template names, the repository they refer 
 | [`community/sig-and-wg`](https://github.com/kyma-project/community/sig-and-wg) | [`DR.md`](./resources/DR.md) | Use the template to document decisions made by SIGs and WGs.
 | [`community/sig-and-wg`](https://github.com/kyma-project/community/sig-and-wg) | [`sig-wg-readme-template.md`](./resources/sig-wg-readme-template.md) | Use the template for the main `README.md` document in a given SIG or WG folder.
 | [`community/sig-and-wg`](https://github.com/kyma-project/community/sig-and-wg) | [`sig-wg-meeting-notes-template.md`](./resources/sig-wg-meeting-notes-template.md) | Use the template to document meeting notes of a given SIG or WG.
+| [`website/src/blog-posts`](https://github.com/kyma-project/website/tree/master/src/blog-posts) | [`release-notes.md`](./resources/release-notes.md) | Use the template to write release notes. This template is dedicated to technical writers.
+| Internal use | [`release-notes-input.md`](./resources/release-notes-input.md) | Use the template to provide input for the release notes. This template is dedicated to product owners.
+
 
 >**NOTE:** Update the table each time you add a new template to the `resources` folder.
 

--- a/guidelines/templates/resources/release-notes-input.md
+++ b/guidelines/templates/resources/release-notes-input.md
@@ -15,4 +15,4 @@
 
 ### {Feature or fix name}
 
-> Write a short paragraph that describes the feature or the fix in details. Include screenshots to illustrate the change better.
+> Write a short paragraph that describes the feature or fix in details. Include screenshots to illustrate the change better.

--- a/guidelines/templates/resources/release-notes-input.md
+++ b/guidelines/templates/resources/release-notes-input.md
@@ -1,0 +1,18 @@
+> This template is dedicated to product owners. Use it to provide input for release notes for your Kyma component. See the template for [release notes](./release-notes.md) to see how your input fits into the whole release notes picture.
+
+## {Component Name}
+
+### Highlight(s)
+
+> Provide the most important feature(s) or fix(es) that you want to expose at the beginning of release notes.
+
+- {Feature or fix name} - {One-sentence description}
+
+> For example, write:
+> [Application Connector modularization](#section-link) - Components have been moved to separate Helm charts.
+
+> List other component features or fixes that you want to include in the release notes. List them as headings and describe them as short paragraphs.
+
+### {Feature or fix name}
+
+> Write a short paragraph that describes the feature or the fix in details. Include screenshots to illustrate the change better.

--- a/guidelines/templates/resources/release-notes-input.md
+++ b/guidelines/templates/resources/release-notes-input.md
@@ -15,4 +15,4 @@
 
 ### {Feature or fix name}
 
-> Write a short paragraph that describes the feature or fix in details and explains what are its benefits for the Kyma users. Include screenshots to illustrate the change better.
+> Write a short paragraph that describes the feature or fix in details and explains its benefits to the Kyma users. Include screenshots to illustrate the change better.

--- a/guidelines/templates/resources/release-notes-input.md
+++ b/guidelines/templates/resources/release-notes-input.md
@@ -11,8 +11,6 @@
 > For example, write:
 > Application Connector modularization - Components have been moved to separate Helm charts.
 
-> List other component features or fixes that you want to include in the release notes. List them as headings and describe them as short paragraphs.
-
 ### {Feature or fix name}
 
-> Write a short paragraph that describes the feature or fix in details and explains its benefits to the Kyma users. Include screenshots to illustrate the change better.
+> List other component features or fixes that you want to include in the release notes. Add each feature or fix as a separate heading and describe it in a short paragraph. The paragraph should not only provide details of the feature or fix but also explain its benefits to the Kyma users. Include screenshots to illustrate the changes better.

--- a/guidelines/templates/resources/release-notes-input.md
+++ b/guidelines/templates/resources/release-notes-input.md
@@ -9,7 +9,7 @@
 - {Feature or fix name} - {One-sentence description}
 
 > For example, write:
-> [Application Connector modularization](#section-link) - Components have been moved to separate Helm charts.
+> Application Connector modularization - Components have been moved to separate Helm charts.
 
 > List other component features or fixes that you want to include in the release notes. List them as headings and describe them as short paragraphs.
 

--- a/guidelines/templates/resources/release-notes-input.md
+++ b/guidelines/templates/resources/release-notes-input.md
@@ -15,4 +15,4 @@
 
 ### {Feature or fix name}
 
-> Write a short paragraph that describes the feature or fix in details. Include screenshots to illustrate the change better.
+> Write a short paragraph that describes the feature or fix in details and explains what are its benefits for the Kyma users. Include screenshots to illustrate the change better.

--- a/guidelines/templates/resources/release-notes.md
+++ b/guidelines/templates/resources/release-notes.md
@@ -1,6 +1,6 @@
-> This template is dedicated to technical writers. Use it to write release notes for Kyma releases. Add them as blog posts under [`website/src/blog-posts/`](https://github.com/kyma-project/website/tree/master/src/blog-posts) and any related screenshots under the `assets` folder. Follow the content-related guidelines and tips for writing [release notes](../../release-notes.md).
+> This template is dedicated to technical writers. Use it to write release notes for Kyma releases. Add them as blog posts under [`website/src/blog-posts/`](https://github.com/kyma-project/website/tree/master/src/blog-posts) and any related screenshots under the [`assets`](https://github.com/kyma-project/website/tree/master/src/blog-posts/assets) folder. Follow the content-related guidelines and tips for writing [release notes](../../release-notes.md).
 
-<!-- Fill in the required metadata for the blog post to render properly on the "kyma-project.io" website. -->
+<!-- Fill in the required metadata for the blog post to render properly on the "kyma-project.io" website. Remember to remove the code block. -->
 
 ```
 ---
@@ -13,7 +13,7 @@ title: "{Release notes title}"
 ---
 ```
 
-<!-- This line adds a button that allows you to download the latest release. Provide the path to the release on GitHub in place of the {path} placeholder and put "Download {version number}" in place of the {content} placeholder. -->
+<!-- This line adds a button that allows you to download the latest release. Provide the path to the release on GitHub in place of the {path} placeholder and put "Download {version number}" in place of the {content} placeholder. Remember to remove the code block. -->
 
 ```
 <a class=“btn-blog” href=“{path}“><span>{content}</span></a>

--- a/guidelines/templates/resources/release-notes.md
+++ b/guidelines/templates/resources/release-notes.md
@@ -1,4 +1,4 @@
-> This template is dedicated to technical writers. Use it to write release notes for Kyma releases. Add them as blog posts under [`website/src/blog-posts/`](https://github.com/kyma-project/website/tree/master/src/blog-posts) and any related screenshots under the [`assets`](https://github.com/kyma-project/website/tree/master/src/blog-posts/assets) folder. Follow the content-related guidelines and tips for writing [release notes](../../release-notes.md).
+> This template is dedicated to technical writers. Use it to write release notes for Kyma releases. Add them as a blog post under [`website/src/blog-posts/`](https://github.com/kyma-project/website/tree/master/src/blog-posts). Place any related screenshots under the [`assets`](https://github.com/kyma-project/website/tree/master/src/blog-posts/assets) folder. Follow the content-related guidelines and tips for writing [release notes](../../release-notes.md).
 
 <!-- Fill in the required metadata for the blog post to render properly on the "kyma-project.io" website. Remember to remove the code block. -->
 
@@ -50,4 +50,4 @@ title: "{Release notes title}"
 
 ### {Feature or fix name}
 
-> Write a short paragraph that describes the feature or the fix in details. Include screenshots to illustrate the change better.
+> Write a short paragraph that describes the feature or the fix in details and explains its benefits to the Kyma users. Include screenshots to illustrate the change better.

--- a/guidelines/templates/resources/release-notes.md
+++ b/guidelines/templates/resources/release-notes.md
@@ -16,7 +16,7 @@ title: "{Release notes title}"
 <!-- This line adds a button that allows you to download the latest release. Provide the path to the release on GitHub in place of the {path} placeholder and put "Download {version number}" in place of the {content} placeholder. Remember to remove the code block. -->
 
 ```
-<a class=“btn-blog” href=“{path}“><span>{content}</span></a>
+<a class="btn-blog" href="{path}"><span>{content}</span></a>
 ```
 
 > Write an introductory paragraph and present the most important release highlights from all components. List the highlights as bullet points and provide absolute links to their corresponding sections.

--- a/guidelines/templates/resources/release-notes.md
+++ b/guidelines/templates/resources/release-notes.md
@@ -19,7 +19,7 @@ title: "{Release notes title}"
 <a class=“btn-blog” href=“{path}“><span>{content}</span></a>
 ```
 
-> Write a staring paragraph and introduce the most important release highlights from all components. List the highlights as bullet points and provide absolute links to given sections.
+> Write an introductory paragraph and present the most important release highlights from all components. List the highlights as bullet points and provide absolute links to their corresponding sections.
 
 - [{Feature or fix name}](#absolute-link-to-subsection) - {One-sentence description}
 - [{Feature or fix name}](#absolute-link-to-subsection) - {One-sentence description}

--- a/guidelines/templates/resources/release-notes.md
+++ b/guidelines/templates/resources/release-notes.md
@@ -28,7 +28,7 @@ title: "{Release notes title}"
 > For example, write:
 > [Application Connector modularization](#modularization) - Components have been moved to separate Helm charts.
 
-> Add the <!-- overview --> comment after this introductory paragraph to separate the excerpt rendered on the main page from the rest of the document. For more details, see [this](https://github.com/kyma-project/website/blob/master/docs/write-blog-posts.md) document.
+> Add the <!-- overview --> comment after this introductory paragraph to separate the excerpt rendered on the main page from the rest of the document. For more details, see [these](https://github.com/kyma-project/website/blob/master/docs/write-blog-posts.md) guidelines.
 
 > Introduce other component features or fixes that are included in the release notes. They should reflect the names of subsections under each component. Add relative links to component sections.
 

--- a/guidelines/templates/resources/release-notes.md
+++ b/guidelines/templates/resources/release-notes.md
@@ -1,0 +1,45 @@
+> This template is dedicated to technical writers. Use it to write release notes for Kyma releases. Add them as blog posts under [`website/src/blog-posts/`](https://github.com/kyma-project/website/tree/master/src/blog-posts) and any related screenshots under the `assets` folder. Follow the content-related guidelines and tips for writing [release notes](../../release-notes.md).
+
+---
+path: "/blog/{link}"
+date: "{YYY-MM-DD}"
+author: "{Name and surname}, {Role} @Kyma"
+tags:
+  - release-notes
+title: "{Release notes title}"
+---
+
+<a class=“btn-blog” href=“{path}“><span>{content}</span></a>
+
+> Write a staring paragraph and introduce the most important release highlights from all components. List the highlights as bullet points and provide absolute links to given sections.
+
+- [{Feature or fix name}](#section-link) - {One-sentence description}
+- [{Feature or fix name}](#section-link) - {One-sentence description}
+- [{Feature or fix name}](#section-link) - {One-sentence description}
+
+> For example, write:
+> [Application Connector modularization](#section-link) - Components have been moved to separate Helm charts.
+
+> Introduce other component features or fixes that are included in the release notes. They should reflect the names of subsections under each component. Add absolute links to component sections.
+
+- [Application Connector](#section-link) - {List of other features and fixes}
+- [Console](#section-link) - {List of other features and fixes}
+- [Eventing](#section-link) - {List of other features and fixes}
+- [Logging](#section-link) - {List of other features and fixes}
+- [Monitoring](#section-link) - {List of other features and fixes}
+- [Security](#section-link) - {List of other features and fixes}
+- [Serverless](#section-link) - {List of other features and fixes}
+- [Service Catalog](#section-link) - {List of other features and fixes}
+- [Service Mesh](#section-link) - {List of other features and fixes}
+- [Tracing](#section-link) - {List of other features and fixes}
+
+> For example, write:
+> [Application Connector](https://kyma-project.io/blog/release-notes-05#application-connector) - Extended tests, client certificate verification
+
+---
+
+## {Component name}
+
+### {Feature or fix name}
+
+> Write a short paragraph that describes the feature or the fix in details. Include screenshots to illustrate the change better.

--- a/guidelines/templates/resources/release-notes.md
+++ b/guidelines/templates/resources/release-notes.md
@@ -2,6 +2,7 @@
 
 <!-- Fill in the required metadata for the blog post to render properly on the "kyma-project.io" website. -->
 
+```
 ---
 path: "/blog/{link}"
 date: "{YYY-MM-DD}"
@@ -10,10 +11,13 @@ tags:
   - release-notes
 title: "{Release notes title}"
 ---
+```
 
-<!-- Fill in the path to the release on GitHub in place of the {path} placeholder and put "Download {version number}" in place of the {content} placeholder". -->
+<!-- This line adds a button that allows you to download the latest release. Provide the path to the release on GitHub in place of the {path} placeholder and put "Download {version number}" in place of the {content} placeholder. -->
 
+```
 <a class=“btn-blog” href=“{path}“><span>{content}</span></a>
+```
 
 > Write a staring paragraph and introduce the most important release highlights from all components. List the highlights as bullet points and provide absolute links to given sections.
 

--- a/guidelines/templates/resources/release-notes.md
+++ b/guidelines/templates/resources/release-notes.md
@@ -1,5 +1,7 @@
 > This template is dedicated to technical writers. Use it to write release notes for Kyma releases. Add them as blog posts under [`website/src/blog-posts/`](https://github.com/kyma-project/website/tree/master/src/blog-posts) and any related screenshots under the `assets` folder. Follow the content-related guidelines and tips for writing [release notes](../../release-notes.md).
 
+<!-- Fill in the required metadata for the blog post to render properly on the "kyma-project.io" website. -->
+
 ---
 path: "/blog/{link}"
 date: "{YYY-MM-DD}"
@@ -8,6 +10,8 @@ tags:
   - release-notes
 title: "{Release notes title}"
 ---
+
+<!-- Fill in the path to the release on GitHub in place of the {path} placeholder and put "Download {version number}" in place of the {content} placeholder". -->
 
 <a class=“btn-blog” href=“{path}“><span>{content}</span></a>
 

--- a/guidelines/templates/resources/release-notes.md
+++ b/guidelines/templates/resources/release-notes.md
@@ -28,7 +28,7 @@ title: "{Release notes title}"
 > For example, write:
 > [Application Connector modularization](#section-link) - Components have been moved to separate Helm charts.
 
-> Remember to add the <!-- overview --> comment after this introductory paragraph to separate the excerpt rendered on the main page from the rest of the document. For more details, see [this](https://github.com/kyma-project/website/blob/master/docs/write-blog-posts.md) document.
+> Add the <!-- overview --> comment after this introductory paragraph to separate the excerpt rendered on the main page from the rest of the document. For more details, see [this](https://github.com/kyma-project/website/blob/master/docs/write-blog-posts.md) document.
 
 > Introduce other component features or fixes that are included in the release notes. They should reflect the names of subsections under each component. Add absolute links to component sections.
 

--- a/guidelines/templates/resources/release-notes.md
+++ b/guidelines/templates/resources/release-notes.md
@@ -16,7 +16,7 @@ title: "{Release notes title}"
 <!-- This line adds a button that allows you to download the latest release. Provide the path to the release on GitHub in place of the {path} placeholder and put "Download {version number}" in place of the {content} placeholder. Remember to remove the code block. -->
 
 ```
-<a class="btn-blog" href="{path}"><span>{content}</span></a>
+<a class="btn-blog" href="{path}" alt="{content}"/a>
 ```
 
 > Write an introductory paragraph and present the most important release highlights from all components. List the highlights as bullet points and provide absolute links to their corresponding sections.
@@ -27,6 +27,8 @@ title: "{Release notes title}"
 
 > For example, write:
 > [Application Connector modularization](#section-link) - Components have been moved to separate Helm charts.
+
+> Remember to add the <!-- overview --> comment after this introductory paragraph to separate the excerpt rendered on the main page from the rest of the document. For more details, see [this](https://github.com/kyma-project/website/blob/master/docs/write-blog-posts.md) document.
 
 > Introduce other component features or fixes that are included in the release notes. They should reflect the names of subsections under each component. Add absolute links to component sections.
 

--- a/guidelines/templates/resources/release-notes.md
+++ b/guidelines/templates/resources/release-notes.md
@@ -21,25 +21,25 @@ title: "{Release notes title}"
 
 > Write a staring paragraph and introduce the most important release highlights from all components. List the highlights as bullet points and provide absolute links to given sections.
 
-- [{Feature or fix name}](#section-link) - {One-sentence description}
-- [{Feature or fix name}](#section-link) - {One-sentence description}
-- [{Feature or fix name}](#section-link) - {One-sentence description}
+- [{Feature or fix name}](#absolute-link-to-subsection) - {One-sentence description}
+- [{Feature or fix name}](#absolute-link-to-subsection) - {One-sentence description}
+- [{Feature or fix name}](#absolute-link-to-subsection) - {One-sentence description}
 
 > For example, write:
 > [Application Connector modularization](#section-link) - Components have been moved to separate Helm charts.
 
 > Introduce other component features or fixes that are included in the release notes. They should reflect the names of subsections under each component. Add absolute links to component sections.
 
-- [Application Connector](#section-link) - {List of other features and fixes}
-- [Console](#section-link) - {List of other features and fixes}
-- [Eventing](#section-link) - {List of other features and fixes}
-- [Logging](#section-link) - {List of other features and fixes}
-- [Monitoring](#section-link) - {List of other features and fixes}
-- [Security](#section-link) - {List of other features and fixes}
-- [Serverless](#section-link) - {List of other features and fixes}
-- [Service Catalog](#section-link) - {List of other features and fixes}
-- [Service Mesh](#section-link) - {List of other features and fixes}
-- [Tracing](#section-link) - {List of other features and fixes}
+- [Application Connector](#absolute-link-to-subsection) - {List of other features and fixes}
+- [Console](#absolute-link-to-subsection) - {List of other features and fixes}
+- [Eventing](#absolute-link-to-subsection) - {List of other features and fixes}
+- [Logging](#absolute-link-to-subsection) - {List of other features and fixes}
+- [Monitoring](#absolute-link-to-subsection) - {List of other features and fixes}
+- [Security](#absolute-link-to-subsection) - {List of other features and fixes}
+- [Serverless](#absolute-link-to-subsection) - {List of other features and fixes}
+- [Service Catalog](#absolute-link-to-subsection) - {List of other features and fixes}
+- [Service Mesh](#absolute-link-to-subsection) - {List of other features and fixes}
+- [Tracing](#absolute-link-to-subsection) - {List of other features and fixes}
 
 > For example, write:
 > [Application Connector](https://kyma-project.io/blog/release-notes-05#application-connector) - Extended tests, client certificate verification

--- a/guidelines/templates/resources/release-notes.md
+++ b/guidelines/templates/resources/release-notes.md
@@ -13,38 +13,38 @@ title: "{Release notes title}"
 ---
 ```
 
-<!-- This line adds a button that allows you to download the latest release. Provide the path to the release on GitHub in place of the {path} placeholder and put "Download {version number}" in place of the {content} placeholder. Remember to remove the code block. -->
+<!-- This line adds a button that allows you to download the latest release. Provide the path to the release on GitHub in place of the {path} placeholder and put "Download {version number}" in place of the {content} placeholders. Remember to remove the code block. -->
 
 ```
-<a class="btn-blog" href="{path}" alt="{content}"/a>
+<a class="btn-blog" href="{path}" alt="{content}">{content}</a>
 ```
 
-> Write an introductory paragraph and present the most important release highlights from all components. List the highlights as bullet points and provide absolute links to their corresponding sections.
+> Write an introductory paragraph and present the most important release highlights from all components. List the highlights as bullet points and provide relative links to their corresponding sections.
 
-- [{Feature or fix name}](#absolute-link-to-subsection) - {One-sentence description}
-- [{Feature or fix name}](#absolute-link-to-subsection) - {One-sentence description}
-- [{Feature or fix name}](#absolute-link-to-subsection) - {One-sentence description}
+- [{Feature or fix name}](#relative-link-to-subsection) - {One-sentence description}
+- [{Feature or fix name}](#relative-link-to-subsection) - {One-sentence description}
+- [{Feature or fix name}](#relative-link-to-subsection) - {One-sentence description}
 
 > For example, write:
-> [Application Connector modularization](#section-link) - Components have been moved to separate Helm charts.
+> [Application Connector modularization](#modularization) - Components have been moved to separate Helm charts.
 
 > Add the <!-- overview --> comment after this introductory paragraph to separate the excerpt rendered on the main page from the rest of the document. For more details, see [this](https://github.com/kyma-project/website/blob/master/docs/write-blog-posts.md) document.
 
-> Introduce other component features or fixes that are included in the release notes. They should reflect the names of subsections under each component. Add absolute links to component sections.
+> Introduce other component features or fixes that are included in the release notes. They should reflect the names of subsections under each component. Add relative links to component sections.
 
-- [Application Connector](#absolute-link-to-subsection) - {List of other features and fixes}
-- [Console](#absolute-link-to-subsection) - {List of other features and fixes}
-- [Eventing](#absolute-link-to-subsection) - {List of other features and fixes}
-- [Logging](#absolute-link-to-subsection) - {List of other features and fixes}
-- [Monitoring](#absolute-link-to-subsection) - {List of other features and fixes}
-- [Security](#absolute-link-to-subsection) - {List of other features and fixes}
-- [Serverless](#absolute-link-to-subsection) - {List of other features and fixes}
-- [Service Catalog](#absolute-link-to-subsection) - {List of other features and fixes}
-- [Service Mesh](#absolute-link-to-subsection) - {List of other features and fixes}
-- [Tracing](#absolute-link-to-subsection) - {List of other features and fixes}
+- [Application Connector](#relative-link-to-subsection) - {List of other features and fixes}
+- [Console](#relative-link-to-subsection) - {List of other features and fixes}
+- [Eventing](#relative-link-to-subsection) - {List of other features and fixes}
+- [Logging](#relative-link-to-subsection) - {List of other features and fixes}
+- [Monitoring](#relative-link-to-subsection) - {List of other features and fixes}
+- [Security](#relative-link-to-subsection) - {List of other features and fixes}
+- [Serverless](#relative-link-to-subsection) - {List of other features and fixes}
+- [Service Catalog](#relative-link-to-subsection) - {List of other features and fixes}
+- [Service Mesh](#relative-link-to-subsection) - {List of other features and fixes}
+- [Tracing](#relative-link-to-subsection) - {List of other features and fixes}
 
 > For example, write:
-> [Application Connector](https://kyma-project.io/blog/release-notes-05#application-connector) - Extended tests, client certificate verification
+> [Application Connector](#application-connector) - Extended tests, client certificate verification
 
 ---
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add a release notes template for technical writers
- Add a release notes template for the product owners input
- Add guidelines that include tips for writing release notes
- Add a `README.md` document in the `content-guidelines` directory
- Add new templates to the table with all templates

**Related issue(s)**
See also #149 
