### PR TITLE
Number the document types

### DIFF
--- a/guidelines/content-guidelines/content-strategy.md
+++ b/guidelines/content-guidelines/content-strategy.md
@@ -7,7 +7,7 @@ Content Strategy is a term that relates to the approach you need to to define be
 * Where the content will be visible
 * What types of content you have
 * How the reader will navigate through the content
-* What is the review process
+* What the review process is
 
 ## Location and context
 
@@ -43,20 +43,20 @@ There is a set of documents that a given technical topic must include. You can a
 
 ### Obligatory
 
-Each technical topic must have the following document types arranged in this fixed order:
+Each technical topic must have the following document types arranged in the fixed order. Follow the `{document-type-number}-(document-number)-{document-name}.md` format to name the documents. For example, use `06-02-clustermicrofrontend.md` to name the second document of the **Custom Resource** type that describes the `clustermicrofrontend.ui.kyma-project.io` CustomResourceDefinition (CRD).
 
 >**NOTE:** The Kyma content developers create templates for a given document type once there are at least two documents to use as a base for such a template.
 
-- [Overview](../templates/resources/overview.md) - Use it to describe the component in general. It serves as an entry point for the topic. Make sure it is short but descriptive.
-- [Architecture](../templates/resources/architecture.md) - Use it to describe in detail the architecture of the component. Include a diagram in this document.
-- [Details](../templates/resources/details.md) - Use it to describe more technical details of the component that do not fit into any other document type. Among other things, include a detailed explanation of the application lifecycle that describes how the resource is created and what other resources are created, how it is updated, how it is removed, and what each operation means from the technical point of view.
-- **Installation** - Use it to describe the installation process. This includes guides for local, cluster, or component installation, as well as documents describing installation scripts.
-- **Configuration** - Use it to describe configuration options for a given component. Define the settings that a user can change and the expected outcome of such changes. Include the table structure with the settings in the document.
-- [Custom Resource](../templates/resources/custom-resource.md) - Use it to document details of CustomResourceDefinitions (CRDs) that are part of a given component.
-- [CLI Reference](../templates/resources/cli-reference.md) - Use it to describe the syntax and the use of CLI commands for a given component.
-- [Tutorials](../templates/resources/tutorials.md) - Use it to provide a clear step-by-step instruction that helps the user to understand a given concept better. The user must be able to go through all the steps of the document and complete them. There is no separate tutorial type. The document does not have to explicitly point out the example used as, at the end, the explicit reference to the example will be in the main content of the guide.
-- **API** - Use it to document the exposed external API of components that the Kyma administrators use to integrate them with Kyma.
-- **Operational Guide** - Use it to describe how to operate the component. Explain all details needed for the component troubleshooting.
+1. [**Overview**](../templates/resources/overview.md) (`01`) - Use it to describe the component in general. It serves as an entry point for the topic. Make sure it is short but descriptive.
+2. [**Architecture**](../templates/resources/architecture.md) (`02`) - Use it to describe in detail the architecture of the component. Include a diagram in this document.
+3. [**Details**](../templates/resources/details.md) (`03`) - Use it to describe more technical details of the component that do not fit into any other document type. Among other things, include a detailed explanation of the application lifecycle that describes how the resource is created and what other resources are created, how it is updated, how it is removed, and what each operation means from the technical point of view.
+4. **Installation** (`04`) - Use it to describe the installation process. This includes guides for local, cluster, or component installation, as well as documents describing installation scripts.
+5. **Configuration** (`05`) - Use it to describe configuration options for a given component. Define the settings that a user can change and the expected outcome of such changes. Include the table structure with the settings in the document.
+6. [**Custom Resource**](../templates/resources/custom-resource.md) (`06`) - Use it to document details of CRDs that are part of a given component.
+7. [**CLI Reference**](../templates/resources/cli-reference.md) (`07`) - Use it to describe the syntax and the use of CLI commands for a given component.
+8. [**Tutorials**](../templates/resources/tutorials.md) (`08`) - Use it to provide a clear step-by-step instruction that helps the user to understand a given concept better. The user must be able to go through all the steps of the document and complete them. There is no separate tutorial type. The document does not have to explicitly point out the example used as, at the end, the explicit reference to the example will be in the main content of the guide.
+9. **API** (`09`) - Use it to document the exposed external API of components that the Kyma administrators use to integrate them with Kyma.
+10. **Operational Guide** (`10`) - Use it to describe how to operate the component. Explain all details needed for the component troubleshooting.
 
 
 ### Optional
@@ -64,8 +64,8 @@ Each technical topic must have the following document types arranged in this fix
 >**NOTE:** Place the optional types of documents right after the obligatory types.
 
 You can add the following document type to the Kyma documentation:
-- **UI Contracts** - Use it to describe the mapping of OSBA service objects, plan objects, and conventions in the Kyma Console view.
-- **Examples** - Use it to demonstrate a given Kyma feature or concept in a form of a short demo.
+- **UI Contracts** (`11`) - Use it to describe the mapping of OSBA service objects, plan objects, and conventions in the Kyma Console view.
+- **Examples** (`12`) - Use it to demonstrate a given Kyma feature or concept in a form of a short demo.
 
 ## The content source
 

--- a/guidelines/templates/resources/architecture.md
+++ b/guidelines/templates/resources/architecture.md
@@ -12,7 +12,7 @@ type: Architecture
 > * Describe all components and sub-components involved in the workflow together with their functions.
 > * Use an ordered list to describe a step-by-step workflow.
 > * Use sections if the document does not describe any workflow but the overall arrangement of the components and sub-components. In this case, each component should be described in a separate section. Use H2 (##) for sections and H3 (###) for sub-sections. Do not use headings smaller than H3 as they do not display well on the UI.
-> * Follow the `{000}-architecture-{component}.md` convention to name the document.
+> * Follow the `02-{00}-{component-name}.md` convention to name the document.
 > * In the metadata section, follow the `{Component name} architecture` convention for the `title` if there are more than one Architecture document in a repository. If there is only one document of a certain type, remove the `type` metadata completely so that the document displays well on the UI.
 >
 > For reference, see the existing **Architecture** document for the [Remote Environment Broker](https://github.com/kyma-project/kyma/blob/master/docs/service-brokers/docs/020-architecture-reb.md).

--- a/guidelines/templates/resources/cli-reference.md
+++ b/guidelines/templates/resources/cli-reference.md
@@ -4,7 +4,7 @@ title: CLI reference
 
 >**NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
 >
-> This document is a ready-to-use template for a Command Line Interface (CLI) reference document type that describes the syntax and the use of CLI commands for a given Kyma component. Put the name of a reference resource and a component in place of {resourcename} and {Component Name}, respectively. Do the same for {CLI tool name} and replace it with `kubectl`, `kubeless`, or `svcat`, depending on the tool you use. Follow the `{000}-cli-reference.md` convention to name the document.
+> This document is a ready-to-use template for a Command Line Interface (CLI) reference document type that describes the syntax and the use of CLI commands for a given Kyma component. Put the name of a reference resource and a component in place of {resourcename} and {Component Name}, respectively. Do the same for {CLI tool name} and replace it with `kubectl`, `kubeless`, or `svcat`, depending on the tool you use. Follow the `07-{00}-cli-reference.md` convention to name the document.
 For reference, see the existing document for the [Service Catalog](https://github.com/kyma-project/kyma/blob/master/docs/service-catalog/docs/030-cli-reference.md).
 
 Management of the {Component Name} is based on the custom resources specifically defined for Kyma. Manage all of these resources through `[{CLI tool name}](link)`.

--- a/guidelines/templates/resources/custom-resource.md
+++ b/guidelines/templates/resources/custom-resource.md
@@ -5,10 +5,10 @@ type: Custom Resource
 
 > **NOTE:** Blockquotes in this document provide instructions. Remove them from the final document. Add more sections to the CR document if you need to explain a given custom resource in more details. Use H2 (##) to introduce a new section.
 >
-> This document is a ready-to-use template for a custom resource (CR) document type that provides a sample custom resource and description of its elements. Additionally, the document points to the CustomResourceDefinition (CRD) used to create CRs of the given kind. Follow the `{000}-cr-{CRD-kind}.md` convention to name the document. If there is only one document of a certain type, remove the `type` metadata completely so that the document displays well on the UI.
+> This document is a ready-to-use template for a custom resource (CR) document type that provides a sample custom resource and description of its elements. Additionally, the document points to the CustomResourceDefinition (CRD) used to create CRs of the given kind. Follow the `06-{00}-{CRD-kind}.md` convention to name the document. If there is only one document of a certain type, remove the `type` metadata completely so that the document displays well on the UI.
 For reference, see the existing documents for the [Installation](https://github.com/kyma-project/kyma/blob/master/docs/kyma/docs/040-cr-installation.md) and the [Api](https://github.com/kyma-project/kyma/blob/master/docs/api-gateway/docs/011-cr-api.md) CRs.
 
-The {CRD name} CustomResourceDefinition (CRD) is a detailed description of the kind of data and the format used to {provide the CRD description}. To get the up-to-date CRD and show the output in the `yaml` format, run this command:
+The `{CRD name}` CustomResourceDefinition (CRD) is a detailed description of the kind of data and the format used to {provide the CRD description}. To get the up-to-date CRD and show the output in the `yaml` format, run this command:
 
 ```
 kubectl get crd {CRD name} -o yaml

--- a/guidelines/templates/resources/details.md
+++ b/guidelines/templates/resources/details.md
@@ -13,7 +13,7 @@ type: Details
 > * Use headings to name sections. Use H2 (##) for the main sections and H3 (###) for the sub-sections. Do not use headings smaller than H3 as they do not display well.
 > * Provide any relevant links to the related external documentation. However, do not use cross-references between documents in the `kyma/docs` folder. Mention the related document title instead and put the document name in bold.
 > * Do not mix different concepts in one document. Instead, describe them in separate documents.
-> * Follow the `{000}-details-{document-title}.md` convention to name the document. The title must summarize what the document is about.
+> * Follow the `03-{00}-{document-title}.md` convention to name the document. The title must summarize what the document is about.
 > * If there is only one document of a certain type, remove the `type` metadata completely so that the document displays well on the UI.
 >
 > For reference, see the existing **Details** document concerning the [Application Connector security](https://github.com/kyma-project/kyma/blob/master/docs/application-connector/docs/011-details-ac-security.md).

--- a/guidelines/templates/resources/overview.md
+++ b/guidelines/templates/resources/overview.md
@@ -14,7 +14,7 @@ type: Overview
 > * Provide its purpose and function.
 > * Be short but descriptive.
 > * Avoid headings. If you want to provide more details, create a separate **Details** document.
-> * Follow the `{000}-overview-{component-name}.md` convention to name the document.
+> * Follow the `01-{00}-{component-name}.md` convention to name the document.
 > * In the metadata section, follow the `{Component name} overview` convention for the `title` if there are more than one Overview document in a repository. If there is only one document of a certain type, remove the `type` metadata completely so that the document displays well on the UI.
 >
 > For reference, see the existing **Overview** document for the [Application Connector](https://github.com/kyma-project/kyma/blob/master/docs/application-connector/docs/001-overview-application-connector.md).

--- a/guidelines/templates/resources/release-notes.md
+++ b/guidelines/templates/resources/release-notes.md
@@ -9,7 +9,7 @@ date: "{YYY-MM-DD}"
 author: "{Name and surname}, {Role} @Kyma"
 tags:
   - release-notes
-title: "{Release notes title}"
+title: "Kyma {release-number} {code-name}"
 ---
 ```
 

--- a/guidelines/templates/resources/tutorials.md
+++ b/guidelines/templates/resources/tutorials.md
@@ -9,7 +9,7 @@ type: Tutorials
 
 >  In the document:
 > * Start with the introductory sentence presented in this template.
-> * Follow the `{000}-tutorials-{document-title}.md` convention to name the document. The title must summarize what it is about.
+> * Follow the `08-{00}-{document-title}.md` convention to name the document. The title must summarize what it is about.
 >
 > For reference, see the existing **Tutorials** document concerning the [Sample service deployment on local machine](https://github.com/kyma-project/kyma/blob/master/docs/kyma/docs/040-gs-sample-service-deployment-to-local.md).
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add fixed document type numbers to `content-strategy.md`
- Update the existing document templates to mention the new numbering and naming convention.

**Related issue(s)**
See also #187
