### PR TITLE
proposal for test folder consolidation

### DIFF
--- a/sig-and-wg/sig-core/proposals/test-folder-consolidation.md
+++ b/sig-and-wg/sig-core/proposals/test-folder-consolidation.md
@@ -1,0 +1,67 @@
+# Test folder consolidation
+
+## Introduction
+The [tests](https://github.com/kyma-project/kyma/tree/master/tests) folder of the kyma-project contains all tests executed against a running kyma cluster to assure integrity and functional correctness of the cluster when all modules are installed together.
+In kyma, that kind of tests are called _acceptance tests_.
+All subfolders in the _tests_ directory define one test suite, usually focussing on one component.
+
+## Problem
+Every subfolder uses a different naming style, like _kubeless_ and _ui-api-layer-acceptance-tests_.
+
+With that:
+- Overall it is not easy to decide which convention to follow when creating a new subfolder.
+- Not always it is possible to derive the related component (there is no e2e test yet, they are all focussed on components).
+- It is confusing for readers
+
+## Goal
+
+Propose a name pattern which places the valuable information, the differentiator of the folder, into the focus.
+
+## Consideration
+
+**kind of test** All tests are of the same style currently, named as _acceptance tests_. As long as there is no different kind of tests available, the information of the kind of test is not valuable as part of the subfolder name
+
+**test prefix/suffix** all subfolders contain test suites. That's why they are located under the _tests_ folder. Having a prefix or suffix in the folder name is redundant and does not bring more value to the reader.
+
+**one component per folder** as long as a test suite is focussing on a specific component under test, the test suite should be named accordingly. With that the component and also the maintainers can be identified more quickly.
+There is one special folder called _acceptance_ currently containing test suites for 3 different components, but sharing some few common scripts. As the tendency is to have a dedicated folder and docker image per component, that folder should be converted into three dedicated component folders with own docker images. Common scripts can be still shared on the root level or a dedicated _common_ folder.
+
+**docker images** Every subfolder is producing a docker image using the folder name as image name. If no prefix/suffix is used, the name will collide with the image of the actual component. To have a differentiation here, a subfolder for the image could be introduced
+
+## Proposal
+
+The subfolder specific to a component should be named like the component, that's it.
+
+No prefix, no suffix, no _acceptance_, no multi-components
+
+The resulting docker image of a subfolder should be located in the subfolder _tests_
+
+**Example**: A component _event-bus_ has its acceptance tests in folder _tests/event-bus_ and produces a docker image _XX/tests/event-bus:0.5.1_
+
+Real e2e scenarios (like kubeles--integration) should be bundled into one subfolder _e2e_. Here we should have one test project which will execute all e2e tests organized by scenarios in different packages.
+
+## Concrete Actions
+
+- Have a readme in the _tests_ folder explaining the naming convention
+- Link the readme in the developer guide
+- Migrate _kubeless-integration_ to _e2e_ project containing e2e scenarios on a per package level resulting in one test suite to be executed.
+- All folders will stay in the root _tests_ folder but will be renamed according to the following table:
+
+| old folder | new folder | action required |
+|------------|------------|-----------------|
+| acceptance | dex | yes |
+| _ | service-catalog | yes |
+| _ | application-controller | yes |
+|api-controller-acceptance-tests|api-controller| yes |
+|application-operator-tests|application-operator| yes |
+|application-registry-tests|application-registry|yes|
+|connector-service-tests|connector-service| yes |
+|event-bus|event-bus| - |
+|gateway-tests|gateway|yes|
+|knative-serving-acceptance|knative-serving|yes|
+|kubeless-integration|e2e|yes|
+|kubeless|kubeless|-|
+|logging|logging|-|
+|test-namespace-controller|namespace-controller|yes|
+|test-logging-monitoring|monitoring|yes|
+|ui-api-layer-acceptance-tests|ui-api-layer|yes|

--- a/sig-and-wg/sig-core/proposals/test-folder-consolidation.md
+++ b/sig-and-wg/sig-core/proposals/test-folder-consolidation.md
@@ -1,17 +1,17 @@
 # Test folder consolidation
 
 ## Introduction
-The [tests](https://github.com/kyma-project/kyma/tree/master/tests) folder of the kyma-project contains all tests executed against a running kyma cluster to assure integrity and functional correctness of the cluster when all modules are installed together.
-In kyma, that kind of tests are called _acceptance tests_.
+The [tests](https://github.com/kyma-project/kyma/tree/master/tests) folder of the kyma-project contains tests executed against a running Kyma cluster to assure integrity and functional correctness of the cluster with all modules installed.
+These are acceptance tests.
 All subfolders in the _tests_ directory define one test suite, usually focussing on one component.
 
 ## Problem
-Every subfolder uses a different naming style, like _kubeless_ and _ui-api-layer-acceptance-tests_.
+Each subfolder uses a different naming style. For example, `kubeless` or `ui-api-layer-acceptance-tests`.
 
-With that:
-- Overall it is not easy to decide which convention to follow when creating a new subfolder.
-- Not always it is possible to derive the related component (there is no e2e test yet, they are all focussed on components).
-- It is confusing for readers
+As a result:
+- It's difficult to decide which convention to follow when creating a new subfolder.
+- It is not always possible to derive the related component (there is no e2e test yet, the tests are all focused on components).
+- It is confusing for readers.
 
 ## Goal
 
@@ -19,33 +19,33 @@ Propose a name pattern which places the valuable information, the differentiator
 
 ## Consideration
 
-**kind of test** All tests are of the same style currently, named as _acceptance tests_. As long as there is no different kind of tests available, the information of the kind of test is not valuable as part of the subfolder name
+**kind of test** Currently, all tests are called **acceptance tests**. As long as there is no different kind of tests available, the test kind is not valuable information as part of the subfolder name.
 
-**test prefix/suffix** all subfolders contain test suites. That's why they are located under the _tests_ folder. Having a prefix or suffix in the folder name is redundant and does not bring more value to the reader.
+**test prefix/suffix** All subfolders contain test suites. That's why they reside in the `test` folder. A prefix or suffix in the folder name is redundant and does not bring more value to the reader.
 
-**one component per folder** as long as a test suite is focussing on a specific component under test, the test suite should be named accordingly. With that the component and also the maintainers can be identified more quickly.
-There is one special folder called _acceptance_ currently containing test suites for 3 different components, but sharing some few common scripts. As the tendency is to have a dedicated folder and docker image per component, that folder should be converted into three dedicated component folders with own docker images. Common scripts can be still shared on the root level or a dedicated _common_ folder.
+**one component per folder** As long as a test suite focuses on a specific component, the test suite should be named accordingly. This way the component and its maintainers can be identified quicker.
+The `acceptance` folder currently contains test suites for 3 different components. These suites share some few common scripts. The best practice is to have a dedicated folder per component, including a docker image. That's why the `acceptance` folder should be converted into three dedicated component folders with their own docker images. Common scripts can be still shared on the root level or in a `common` folder.
 
-**docker images** Every subfolder is producing a docker image using the folder name as image name. If no prefix/suffix is used, the name will collide with the image of the actual component. To have a differentiation here, a subfolder for the image could be introduced
+**docker images** Each subfolder produces a docker image using the folder name for the image name. If no prefix/suffix is used, the folder and image names can be conflicting. Introducing a subfolder for the image could solve this problem. 
 
 ## Proposal
 
-The subfolder specific to a component should be named like the component, that's it.
+Use the component's name for the component-specific subfolder.
 
-No prefix, no suffix, no _acceptance_, no multi-components
+No prefix, no suffix, no `acceptance` no multi-components.
 
-The resulting docker image of a subfolder should be located in the subfolder _tests_
+The docker image for a subfolder should reside in the `tests` subfolder.
 
 **Example**: A component _event-bus_ has its acceptance tests in folder _tests/event-bus_ and produces a docker image _XX/tests/event-bus:0.5.1_
 
 Real e2e scenarios (like kubeles--integration) should be bundled into one subfolder _e2e_. Here we should have one test project which will execute all e2e tests organized by scenarios in different packages.
 
-## Concrete Actions
+## Actions
 
-- Have a readme in the _tests_ folder explaining the naming convention
-- Link the readme in the developer guide
-- Migrate _kubeless-integration_ to _e2e_ project containing e2e scenarios on a per package level resulting in one test suite to be executed.
-- All folders will stay in the root _tests_ folder but will be renamed according to the following table:
+- Include a `README.md` file in the `tests` folder to explain the naming convention.
+- Link the `README.md` file in the developer guide.
+- Migrate the `kubeless-integration_ to _e2e` project containing e2e scenarios on the package level to have one test suite.
+- Keep all folders in the root `tests` folder rename them according to the information in this table:
 
 | old folder | new folder | action required |
 |------------|------------|-----------------|

--- a/sig-and-wg/sig-core/proposals/test-folder-consolidation.md
+++ b/sig-and-wg/sig-core/proposals/test-folder-consolidation.md
@@ -3,7 +3,7 @@
 ## Introduction
 The [tests](https://github.com/kyma-project/kyma/tree/master/tests) folder of the kyma-project contains tests executed against a running Kyma cluster to assure integrity and functional correctness of the cluster with all modules installed.
 These are acceptance tests.
-All subfolders in the _tests_ directory define one test suite, usually focussing on one component.
+All subfolders in the `tests` directory define one test suite, usually focusing on one component.
 
 ## Problem
 Each subfolder uses a different naming style. For example, `kubeless` or `ui-api-layer-acceptance-tests`.
@@ -15,7 +15,7 @@ As a result:
 
 ## Goal
 
-Propose a name pattern which places the valuable information, the differentiator of the folder, into the focus.
+Propose a name pattern using specific information to distinguish between the folders.
 
 ## Consideration
 
@@ -36,9 +36,9 @@ No prefix, no suffix, no `acceptance` no multi-components.
 
 The docker image for a subfolder should reside in the `tests` subfolder.
 
-**Example**: A component _event-bus_ has its acceptance tests in folder _tests/event-bus_ and produces a docker image _XX/tests/event-bus:0.5.1_
+**Example**: The Event-Bus component has its acceptance tests in the `tests/event-bus` folder and produces a docker image named like `XX/tests/event-bus:0.5.1`
 
-Real e2e scenarios (like kubeles--integration) should be bundled into one subfolder _e2e_. Here we should have one test project which will execute all e2e tests organized by scenarios in different packages.
++ Bundle the real e2e scenarios (like kubeless-integration) into one `e2e` subfolder. Here we should have one test project which executes all e2e tests divided by scenarios to different packages.
 
 ## Actions
 

--- a/sig-and-wg/sig-core/proposals/test-folder-consolidation.md
+++ b/sig-and-wg/sig-core/proposals/test-folder-consolidation.md
@@ -6,12 +6,12 @@ These are acceptance tests.
 All subfolders in the `tests` directory define one test suite, usually focusing on one component.
 
 ## Problem
-Each subfolder uses a different naming style. For example, `kubeless` or `ui-api-layer-acceptance-tests`.
+Each subfolder uses a different naming pattern. For example, `kubeless` or `ui-api-layer-acceptance-tests`.
 
 As a result:
 - It's difficult to decide which convention to follow when creating a new subfolder.
-- It is not always possible to derive the related component (there is no e2e test yet, the tests are all focused on components).
-- It is confusing for readers.
+- It's not always possible to derive the related component (there is no e2e test yet, the tests are focused on components).
+- It's confusing for readers.
 
 ## Goal
 
@@ -34,17 +34,17 @@ Use the component's name for the component-specific subfolder.
 
 No prefix, no suffix, no `acceptance` no multi-components.
 
-The docker image for a subfolder should reside in the `tests` subfolder.
+The docker image for a subfolder resides in the `tests` subfolder.
 
-**Example**: The Event-Bus component has its acceptance tests in the `tests/event-bus` folder and produces a docker image named like `XX/tests/event-bus:0.5.1`
+**Example**: The Event-Bus component has its acceptance tests in the `tests/event-bus` folder and produces the `XX/tests/event-bus:0.5.1` docker image.
 
-+ Bundle the real e2e scenarios (like kubeless-integration) into one `e2e` subfolder. Here we should have one test project which executes all e2e tests divided by scenarios to different packages.
++ Bundle the real e2e scenarios (like kubeless-integration) into one `e2e` subfolder. Here we should have one test project which executes all e2e tests divided by scenarios into different packages.
 
 ## Actions
 
 - Include a `README.md` file in the `tests` folder to explain the naming convention.
-- Link the `README.md` file in the developer guide.
-- Migrate the `kubeless-integration_ to _e2e` project containing e2e scenarios on the package level to have one test suite.
+- Link the `README.md` file in the developer's guide.
+- Migrate the `kubeless-integration` to `e2e` project containing e2e scenarios on the package level to have one test suite.
 - Keep all folders in the root `tests` folder rename them according to the information in this table:
 
 | old folder | new folder | action required |


### PR DESCRIPTION
Created on 2019-01-19 by Andreas Thaler (@Github a-thaler).

## Decision log

| Name | Description |
|-----------------------|------------------------------------------------------------------------------------|
| Title | Introduce a naming pattern for projects in the tests folder and apply the pattern for the existing projects. |
| Ultimate decision maker(s) | me |
| Due date | 2019-01-30 |
| Status | Proposed on 2019-01-19|
| Input provider(s) | All kyma contributors |
| Group(s) affected by the decision | All kyma contributors |
| Decision type | `Binary` |
| Earliest date to revisit the decision | 2019-02-01 |
| Affected decisions | `None`|

## Context
This decision proposes a change in the kyma-project/kyma/tests folder by proposing a consistent naming pattern for the projects inside that folder. New projects should follow the naming pattern and existing projects should be adjusted to it.

## Decision
A naming pattern needs to be agreed on and the decision to apply to it to all existing projects inside the tests folder.

## Consequences
It will cause a lot of renaming effort but will introduce a consistent naming and with that a better maintainability for the test projects.
