### PR TITLE
Add Service Brokers doc type to the `content-strategy` document

### DIFF
--- a/guidelines/add-new-component-docs.md
+++ b/guidelines/add-new-component-docs.md
@@ -2,30 +2,29 @@
 
 When you add a new component to the `kyma/docs` folder, you must ensure that the content also shows on the `https://kyma-project.io/` website and in the Console UI. To do so, update the following files:
 
-- [`resources/core/charts/docs/charts/documentation/templates/docs-job.yaml`](https://github.com/kyma-project/kyma/blob/master/resources/core/charts/docs/charts/documentation/templates/docs-job.yaml)
-- [`docs/manifest.yaml`](https://github.com/kyma-project/kyma/blob/master/docs/manifest.yaml)
-- [`kyma/docs/docs-build.yaml`](https://github.com/kyma-project/kyma/blob/master/docs/docs-build.yaml)
-
-The `docs-job.yaml` file defines Docker images with documentation which are run to upload this documentation to Minio.
-
-The `docs/manifest.yaml` file specifies the order of documentation topics on the website. If you do not include the component in this file, it doesn't show on the UI.
-
-The `docs-build.yaml` file specifies all documentation topics needed for building Docker images. Every item must have the `name` field specified, which represents the name of the Docker image for a topic. The final image name is followed by a `-docs` suffix. If the name of the new component directory matches the name of the image, you don’t have to specify it. Otherwise, add an additional `directory` property.
-
-Example 1:
-```
-- name: test
-```
-
-This example builds the `test-docs` image from the `kyma/docs/test` directory.
+- [`docs-job.yaml`](https://github.com/kyma-project/kyma/blob/master/resources/core/charts/docs/charts/documentation/templates/docs-job.yaml) - defines Docker images with documentation which are run to upload this documentation to Minio.
+- [`manifest.yaml`](https://github.com/kyma-project/kyma/blob/master/docs/manifest.yaml) - specifies the order of documentation topics on the website. If you do not include the component in this file, it doesn't show on the UI.
+- [`docs-build.yaml`](https://github.com/kyma-project/kyma/blob/master/docs/docs-build.yaml) - specifies all documentation topics needed for building Docker images. Every item must have the `name` field specified, which represents the name of the Docker image for a topic. The final image name is followed by a `-docs` suffix. If the name of the new component directory matches the name of the image, you don’t have to specify it. Otherwise, add an additional `directory` property.
 
 
-Example 2:
-```
-- name: example-two
+  Example 1:
+  ```
+  - name: test
+  ```
+
+  This example builds the `test-docs` image from the `kyma/docs/test` directory.
+
+
+  Example 2:
+  ```
+  - name: example-two
   directory: test/example
-```
+  ```
 
-This example builds the `example-two-docs` image from the `kyma/docs/test/example` directory.
+  This example builds the `example-two-docs` image from the `kyma/docs/test/example` directory.
 
->**NOTE:** You must update the `docs-job.yaml` file in a separate pull request after you update two other files and merge your changes to the `master` branch. After the update, `docs-job.yaml` pushes the existing docs images to Minio and the documentation appears on the Console UI.
+Follow these steps to add a new component to the Kyma documentation:
+
+1. Update the `docs-build.yaml` and the `manifest.yaml` files, and merge your changes to the `master` branch.
+2. Bump the image version of the docs.
+3. Update the `docs-job.yaml` file in a separate pull request to push the existing docs images to Minio and make the documentation visible on the Console UI.

--- a/guidelines/add-new-component-docs.md
+++ b/guidelines/add-new-component-docs.md
@@ -2,9 +2,9 @@
 
 When you add a new component to the `kyma/docs` folder, you must ensure that the content also shows on the `https://kyma-project.io/` website and in the Console UI. To do so, update the following files:
 
-- [`docs-job.yaml`](https://github.com/kyma-project/kyma/blob/master/resources/core/charts/docs/charts/documentation/templates/docs-job.yaml) - defines Docker images with documentation which are run to upload this documentation to Minio.
-- [`manifest.yaml`](https://github.com/kyma-project/kyma/blob/master/docs/manifest.yaml) - specifies the order of documentation topics on the website. If you do not include the component in this file, it doesn't show on the UI.
-- [`docs-build.yaml`](https://github.com/kyma-project/kyma/blob/master/docs/docs-build.yaml) - specifies all documentation topics needed for building Docker images. Every item must have the `name` field specified, which represents the name of the Docker image for a topic. The final image name is followed by a `-docs` suffix. If the name of the new component directory matches the name of the image, you don’t have to specify it. Otherwise, add an additional `directory` property.
+- [`docs-job.yaml`](https://github.com/kyma-project/kyma/blob/master/resources/core/charts/docs/charts/documentation/templates/docs-job.yaml) defines Docker images with documentation which are run to upload this documentation to Minio.
+- [`manifest.yaml`](https://github.com/kyma-project/kyma/blob/master/docs/manifest.yaml) specifies the order of documentation topics on the website. If you do not include the component in this file, it doesn't show on the UI.
+- [`docs-build.yaml`](https://github.com/kyma-project/kyma/blob/master/docs/docs-build.yaml) specifies all documentation topics needed for building Docker images. Every item must have the **name** field specified, which represents the name of the Docker image for a topic. The final image name is followed by a `-docs` suffix. If the name of the new component directory matches the name of the image, you don’t have to specify it. Otherwise, add an additional **directory** property.
 
 
   Example 1:
@@ -26,5 +26,5 @@ When you add a new component to the `kyma/docs` folder, you must ensure that the
 Follow these steps to add a new component to the Kyma documentation:
 
 1. Update the `docs-build.yaml` and the `manifest.yaml` files, and merge your changes to the `master` branch.
-2. Bump the image version of the docs.
-3. Update the `docs-job.yaml` file in a separate pull request to push the existing docs images to Minio and make the documentation visible on the Console UI.
+2. Update the image version of the docs.
+3. Update the `docs-job.yaml` file in a separate pull request to push the existing documentation images to Minio and make the documentation visible on the Console UI.

--- a/guidelines/content-guidelines/content-strategy.md
+++ b/guidelines/content-guidelines/content-strategy.md
@@ -66,10 +66,11 @@ Each technical topic must have the following document types arranged in the fixe
 You can add the following document type to the Kyma documentation:
 - **UI Contracts** (`11`) - Use it to describe the mapping of OSBA service objects, plan objects, and conventions in the Kyma Console view.
 - **Examples** (`12`) - Use it to demonstrate a given Kyma feature or concept in a form of a short demo.
+- **Service Brokers** (`13`) - Use it to describe Service Brokers that Kyma provides
 
 ## The content source
 
-The Kyma content developers write the content in [markdown](https://daringfireball.net/projects/markdown/) and store it in [Git](https://git-scm.com/) repositories.
+The Kyma content developers write the content in [Markdown](https://daringfireball.net/projects/markdown/) and store it in [Git](https://git-scm.com/) repositories.
 
 ## Audience
 

--- a/guidelines/content-guidelines/content-strategy.md
+++ b/guidelines/content-guidelines/content-strategy.md
@@ -66,7 +66,7 @@ Each technical topic must have the following document types arranged in the fixe
 You can add the following document type to the Kyma documentation:
 - **UI Contracts** (`11`) - Use it to describe the mapping of OSBA service objects, plan objects, and conventions in the Kyma Console view.
 - **Examples** (`12`) - Use it to demonstrate a given Kyma feature or concept in a form of a short demo.
-- **Service Brokers** (`13`) - Use it to describe Service Brokers that Kyma provides
+- **Service Brokers** (`13`) - Use it to describe Service Brokers that Kyma provides.
 
 ## The content source
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add Service Brokers doc type to the `content-strategy` document
- Improve the instruction on how to add a new doc topic to the Kyma documentation

