### PR TITLE
Removed an empty doc on golang standards

### DIFF
--- a/guidelines/coding-standards/README.md
+++ b/guidelines/coding-standards/README.md
@@ -1,7 +1,6 @@
 # Coding Standards
 
-This guide covers the best development practices every Kyma team should employ. 
+This guide covers the best development practices every Kyma team should employ.
 
 ## Table of Contents
-- [Golang conventions](golang.md): See the best practices for developing in Go.
 - [Helm charts](helm.md): Learn our best practices and conventions for creating charts.

--- a/guidelines/coding-standards/golang.md
+++ b/guidelines/coding-standards/golang.md
@@ -1,3 +1,0 @@
-# Golang Best Practices Guide
-
-This guide covers the best Golang development practices every Kyma team should employ. 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Removed an empty doc prepared for collecting Golang best practices.
- Removed the reference to the doc from the `README.md` document.

