### PR TITLE
Add guide about links in docs

### DIFF
--- a/guidelines/content-guidelines/documentation-toggle.md
+++ b/guidelines/content-guidelines/documentation-toggle.md
@@ -9,7 +9,7 @@ You can use the toggle to include instructions for different operating systems (
 
 Follow these rules when inserting toggles in documents:
 
-* Toggles belonging to one group must start with `<div tabs>` and end with `</div>` HTML tags.
+* Toggles belonging to one group must start with `<div tabs>` or `<div tabs name="{NAME}">` and end with `</div>` HTML tags, where `{NAME}` is optional distinctive ID used for links. `name` attribute can be ommited if there are no headers inside tabs. It's use is explained more throughly in [this](./links-in-docs.md#links-in-documentation-toggle) document.
 * A single toggle must start with the `<details>` tag and end with the `</details>` tag.
 * Insert the title of the toggle between `<summary>` and `</summary>` tags. Every part of the title must start from a new line.
 

--- a/guidelines/content-guidelines/links-in-docs.md
+++ b/guidelines/content-guidelines/links-in-docs.md
@@ -2,7 +2,7 @@
 
 These are the guidelines for making cross-references between the documents in the [`kyma/docs`](https://github.com/kyma-project/kyma/tree/master/docs) folder.
 
->**NOTE:** The linking works only on the [Kyma website](https://kyma-project.io/docs). Currently, the cross-references between [GitHub documentation](ttps://github.com/kyma-project/kyma/tree/master/docs) is not available.
+>**NOTE:** The linking works only on the [Kyma website](https://kyma-project.io/docs). Currently, the cross-references between [GitHub documentation](https://github.com/kyma-project/kyma/tree/master/docs) is not available.
 
 ## Links between documents in the same topic
 
@@ -41,3 +41,35 @@ If the `{type}` doesn't exist, the pattern has the form of `/{type-of-topic}/{id
 ![Different topic reference](../../assets/reference-2.png)
 
 ![Kyma reference](../../assets/reference-3.png)
+
+## Links in documentation toggle
+
+To link to document inside the documentation toggle it needs to start with `<div tabs name="{toggle-name}">` and end with `</div>` HTML tags, where `{NAME}` is optional distinctive ID used for links. Use of toggle is explained in detail in [this](./documentation-toggle.md) document.
+
+If you want to link to a document in a documentation toggle, create an appropriate reference using instructions from previous sections, additionally adding `--{toggle-name}--{tab-name}--{header}`, where 
+- `{toggle-name}` is value added to specific toggle in `name` attribute
+- `{tab-name}` is the title of the tab containing desired header
+- `{header}` is a header located in the document that you want to reference.
+
+Use lowercase Kebab-Case for those variables, ommiting `-` on the end of expression 
+
+<!-- i don't know whether to write about full proces:
+1. change anything that is not a letter or number into -
+2. cut trailing `-`
+3. change any adjacent `-` into single `-`, e.g. following those rules: 
+expression: `sit (amet)`
+1. sit--amet-
+2. sit--amet
+3. sit-amet
+
+and number 3 is correct
+ -->
+
+Example: 
+1. header `Choose the release to install` becomes `choose-the-release-to-install`
+2. `Lorem ipsum dolor sit (amet)` becomes `lorem-ipsum-dolor-sit-amet`
+
+Example: https://kyma-project.io/docs/master#installation-install-kyma-on-a-cluster--provider-installation--aks--choose-the-release-to-install in which:
+- `{toggle-name}` is `provider-installation`
+- `{tab-name}` is `aks`
+- `{header}` is `choose-the-release-to-install`

--- a/guidelines/content-guidelines/links-in-docs.md
+++ b/guidelines/content-guidelines/links-in-docs.md
@@ -51,7 +51,7 @@ If you want to link to a document in a documentation toggle, create an appropria
 - `{tab-name}` is the title of the tab containing desired header
 - `{header}` is a header located in the document that you want to reference.
 
-Use lowercase Kebab-Case for those variables, ommiting `-` on the end of expression 
+Use lowercase Kebab-Case for those variables, changing any character that is not letter or number into `-`, cutting trailing `-` that emerged in a process and squashing consecutive `-` into one `-`.
 
 <!-- i don't know whether to write about full proces:
 1. change anything that is not a letter or number into -

--- a/guidelines/content-guidelines/links-in-docs.md
+++ b/guidelines/content-guidelines/links-in-docs.md
@@ -53,23 +53,11 @@ If you want to link to a document in a documentation toggle, create an appropria
 
 Use lowercase Kebab-Case for those variables, changing any character that is not letter or number into `-`, cutting trailing `-` that emerged in a process and squashing consecutive `-` into one `-`.
 
-<!-- i don't know whether to write about full proces:
-1. change anything that is not a letter or number into -
-2. cut trailing `-`
-3. change any adjacent `-` into single `-`, e.g. following those rules: 
-expression: `sit (amet)`
-1. sit--amet-
-2. sit--amet
-3. sit-amet
-
-and number 3 is correct
- -->
-
 Example: 
 1. header `Choose the release to install` becomes `choose-the-release-to-install`
 2. `Lorem ipsum dolor sit (amet)` becomes `lorem-ipsum-dolor-sit-amet`
 
-Example: https://kyma-project.io/docs/master#installation-install-kyma-on-a-cluster--provider-installation--aks--choose-the-release-to-install in which:
+Example: https://kyma-project.io/docs/master#installation-install-kyma-on-a-cluster--provider-installation--gke--choose-the-release-to-install in which:
 - `{toggle-name}` is `provider-installation`
-- `{tab-name}` is `aks`
+- `{tab-name}` is `gke`
 - `{header}` is `choose-the-release-to-install`


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/master/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/master/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- add guide about linking to headers inside documentation toggle inside tabs in website 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

Resolves https://github.com/kyma-project/website/issues/301
