### PR TITLE
Remove internal link from example about security

### DIFF
--- a/guidelines/templates/resources/release-notes-input.md
+++ b/guidelines/templates/resources/release-notes-input.md
@@ -27,4 +27,4 @@
 - {Short issue description} - {Issue link} - {Calculated risk assessment} - {PR link}
 
 >For example, write:
-> Prow jobs access Kyma test cluster using insecure channels - [Issue](https://github.wdf.sap.corp/SAP-CP-Extension-Factory/commercialization/issues/260) - CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L **5.6 (Medium)** - {PR link}
+> Prow jobs access Kyma test cluster using insecure channels - [Issue](https://github.com/kyma-project/kyma/issues/5080) - CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L **5.6 (Medium)** - {PR link}

--- a/guidelines/templates/resources/release-notes-input.md
+++ b/guidelines/templates/resources/release-notes-input.md
@@ -23,7 +23,7 @@
 
 ### Security vulnerabilities fixed
 
-> List the solved security vulnerability issues related to the Kyma project. Provide a short issue description, its calculated risk assessment, and a link to the pull request that solves the issue. You can also include a GitHub link to the issue itself. The calculated risk assessment is provided in each issue of the `Security Vulnerability` type created on Github. 
+> List the solved security vulnerability issues related to the Kyma project. Provide a short issue description, its calculated risk assessment, and a link to the pull request that solves the issue. You can also include a GitHub link to the issue itself. The calculated risk assessment is provided in each issue of the [`Security Vulnerability`](https://github.com/kyma-project/kyma/issues/new?template=security-vulnerability.md) type created on Github. 
 - {Short issue description} - {Issue link} - {Calculated risk assessment} - {PR link}
 
 >For example, write:

--- a/guidelines/templates/resources/release-notes-input.md
+++ b/guidelines/templates/resources/release-notes-input.md
@@ -27,4 +27,4 @@
 - {Short issue description} - {Issue link} - {Calculated risk assessment} - {PR link}
 
 >For example, write:
-> Prow jobs access Kyma test cluster using insecure channels - [Issue](https://github.com/kyma-project/kyma/issues/5080) - CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L **5.6 (Medium)** - {PR link}
+> Update the K8s version in the Asset Store Controller Manager - [Issue](https://github.com/kyma-project/kyma/issues/5080) - CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H **8.1 (High)** - {PR link}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove internal link from example about security. Template about release notes input should point to example available for all
