### PR TITLE
Add missing codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners of the repository
-* @kazydek @klaudiagrz @tomekpapiernik @bszwarc @mmitoraj
+* @kazydek @klaudiagrz @tomekpapiernik @bszwarc @mmitoraj @majakurcius @alexandra-simeonova
 
 # Owners of the manifesto-app folder
 /manifesto-app/ @akucharska @michal-hudy @pkosiec @aerfio @derberg @aerfio @magicmatatjahu
@@ -8,7 +8,7 @@
 /collaboration/ @PK85 @mszostok @Abd4llA @derberg
 
 # Owners of all .md files in the repository
-*.md @kazydek @klaudiagrz @tomekpapiernik @bszwarc @mmitoraj
+*.md @kazydek @klaudiagrz @tomekpapiernik @bszwarc @mmitoraj @majakurcius @alexandra-simeonova
 
 # Owners of config file for MILV - milv.config.yaml
 milv.config.yaml @akucharska @michal-hudy @pkosiec @aerfio @magicmatatjahu


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Added @majakurcius @alexandra-simeonova as code owners of `.md` files and the repo root.



