### PR TITLE
Update content strategy and add a template for metrics docs type

### DIFF
--- a/guidelines/content-guidelines/01-content-strategy.md
+++ b/guidelines/content-guidelines/01-content-strategy.md
@@ -3,13 +3,14 @@ title: Content Strategy
 ---
 
 Content Strategy is a term that relates to the approach you need to to define before you start content development. You need to know:
-* Who you write for
-* What to document
-* How and where to develop the content
-* Where the content will be visible
-* What types of content you have
-* How the reader will navigate through the content
-* What the review process is
+
+- Who you write for
+- What to document
+- How and where to develop the content
+- Where the content will be visible
+- What types of content you have
+- How the reader will navigate through the content
+- What the review process is
 
 ## Location and context
 
@@ -18,6 +19,7 @@ One of the main Kyma principles is to care about the developer experience. That 
 It is important to remember that you need to convince developers to use Kyma before they start to work on it. That is why technical documentation must be exposed to the public without a prerequisite to start a cluster first. Publicly available documentation should not only contain the technical content but also a more overarching explanation and showcases that help to convince developers and the business decision makers to use Kyma.
 
 This reasoning leads to a strategy of having two different locations for the documentation:
+
 - A specific Kyma instance (cluster):
     - Contextual help in the Service Catalog so the Kyma user does not have to search for the documentation of a specific service in the general location.
     - The Docs view in the Console UI with the overarching documentation.
@@ -26,8 +28,9 @@ This reasoning leads to a strategy of having two different locations for the doc
 ## Structure
 
 The decision for the document structure is to take a standard approach with the topic-oriented documentation. Looking at the structure of Kyma, there are two types of topics to differentiate:
-* Component
-* Task
+
+- Component
+- Task
 
 The content creation starts with the component-oriented structure that is easier to follow without clear customer expectations. In the long-term, once the Kyma content developers create the whole content and know what customers want, they need to assess the task-oriented structure.
 
@@ -36,6 +39,7 @@ To be more precise, now readers need to know at the start what such terms as `Se
 ## Topic types
 
 Every independent Kyma component is a separate documentation topic. The only exceptions from this rule are as follows:
+
 - Kyma is an overall topic treated as a grouping point for the overarching Kyma documentation.
 - For the publicly available documentation, there needs to be a separate topic for handling more business and marketing-oriented documentation with showcases.
 
@@ -59,12 +63,14 @@ Each technical topic must have the following document types arranged in the fixe
 8. [**Tutorials**](https://github.com/kyma-project/community/blob/master/guidelines/templates/resources/tutorials.md) (`08`) - Use it to provide a clear step-by-step instruction that helps the user to understand a given concept better. The user must be able to go through all the steps of the document and complete them. There is no separate tutorial type. The document does not have to explicitly point out the example used as, at the end, the explicit reference to the example will be in the main content of the guide.
 9. **API** (`09`) - Use it to document the exposed external API of components that the Kyma administrators use to integrate them with Kyma.
 10. [**Troubleshooting**](https://github.com/kyma-project/community/blob/master/guidelines/templates/resources/troubleshooting.md) (`10`) - Use it to explain all details needed for Kyma and its components' troubleshooting.
+11. [**Metrics**](https://github.com/kyma-project/community/blob/master/guidelines/templates/resources/metrics.md) (`14`) - Use it to describe custom and default service or controller metrics.
 
 ### Optional
 
 >**NOTE:** Place the optional types of documents right after the obligatory types.
 
 You can add the following document type to the Kyma documentation:
+
 - **UI Contracts** (`11`) - Use it to describe the mapping of OSBA service objects, plan objects, and conventions in the Kyma Console view.
 - **Examples** (`12`) - Use it to demonstrate a given Kyma feature or concept in a form of a short demo.
 - **Service Brokers** (`13`) - Use it to describe Service Brokers that Kyma provides.
@@ -76,10 +82,12 @@ The Kyma content developers write the content in [Markdown](https://daringfireba
 ## Audience
 
 For the documentation that is part of the Kyma cluster, the audience is the Kyma user. The assumption is that a person that gained access to the cluster and can sign in to the Console already knows the basics and knows what to use Kyma for. Therefore, the intended audience are the following technical people that operate the cluster:
+
 - Developers
 - Administrators
 
 As for the documentation that is published in the publicly available portal, the audience is much more diverse and it requires much more documentation to understand what Kyma is. Nevertheless, the assumption is that the audience has the basic technical understanding of such terms as containers, cloud, and Kubernetes:
+
 - Developers
 - Technical analysts
 - Business decision makers
@@ -91,6 +99,7 @@ Because of such a diversified audience, the navigation of the Kyma portal needs 
 ### The assumed reader's knowledge
 
 The assumption is that the audience is familiar with the following terms and does not require the explanation of technical concepts behind them:
+
 - Kubernetes
 - Docker and containers
 

--- a/guidelines/content-guidelines/01-content-strategy.md
+++ b/guidelines/content-guidelines/01-content-strategy.md
@@ -63,7 +63,7 @@ Each technical topic must have the following document types arranged in the fixe
 8. [**Tutorials**](https://github.com/kyma-project/community/blob/master/guidelines/templates/resources/tutorials.md) (`08`) - Use it to provide a clear step-by-step instruction that helps the user to understand a given concept better. The user must be able to go through all the steps of the document and complete them. There is no separate tutorial type. The document does not have to explicitly point out the example used as, at the end, the explicit reference to the example will be in the main content of the guide.
 9. **API** (`09`) - Use it to document the exposed external API of components that the Kyma administrators use to integrate them with Kyma.
 10. [**Troubleshooting**](https://github.com/kyma-project/community/blob/master/guidelines/templates/resources/troubleshooting.md) (`10`) - Use it to explain all details needed for Kyma and its components' troubleshooting.
-11. [**Metrics**](https://github.com/kyma-project/community/blob/master/guidelines/templates/resources/metrics.md) (`14`) - Use it to describe custom and default service or controller metrics.
+11. [**Metrics**](https://github.com/kyma-project/community/blob/master/guidelines/templates/resources/metrics.md) (`11`) - Use it to describe custom and default service or controller metrics.
 
 ### Optional
 
@@ -71,9 +71,9 @@ Each technical topic must have the following document types arranged in the fixe
 
 You can add the following document type to the Kyma documentation:
 
-- **UI Contracts** (`11`) - Use it to describe the mapping of OSBA service objects, plan objects, and conventions in the Kyma Console view.
-- **Examples** (`12`) - Use it to demonstrate a given Kyma feature or concept in a form of a short demo.
-- **Service Brokers** (`13`) - Use it to describe Service Brokers that Kyma provides.
+- **UI Contracts** (`15`) - Use it to describe the mapping of OSBA service objects, plan objects, and conventions in the Kyma Console view.
+- **Examples** (`16`) - Use it to demonstrate a given Kyma feature or concept in a form of a short demo.
+- **Service Brokers** (`17`) - Use it to describe Service Brokers that Kyma provides.
 
 ## The content source
 

--- a/guidelines/content-guidelines/01-content-strategy.md
+++ b/guidelines/content-guidelines/01-content-strategy.md
@@ -63,7 +63,7 @@ Each technical topic must have the following document types arranged in the fixe
 8. [**Tutorials**](https://github.com/kyma-project/community/blob/master/guidelines/templates/resources/tutorials.md) (`08`) - Use it to provide a clear step-by-step instruction that helps the user to understand a given concept better. The user must be able to go through all the steps of the document and complete them. There is no separate tutorial type. The document does not have to explicitly point out the example used as, at the end, the explicit reference to the example will be in the main content of the guide.
 9. **API** (`09`) - Use it to document the exposed external API of components that the Kyma administrators use to integrate them with Kyma.
 10. [**Troubleshooting**](https://github.com/kyma-project/community/blob/master/guidelines/templates/resources/troubleshooting.md) (`10`) - Use it to explain all details needed for Kyma and its components' troubleshooting.
-11. [**Metrics**](https://github.com/kyma-project/community/blob/master/guidelines/templates/resources/metrics.md) (`11`) - Use it to describe custom and default service or controller metrics.
+11. [**Metrics**](https://github.com/kyma-project/community/blob/master/guidelines/templates/resources/metrics.md) (`11`) - Use it to describe custom and default metrics for services or controllers.
 
 ### Optional
 

--- a/guidelines/templates/resources/configuration.md
+++ b/guidelines/templates/resources/configuration.md
@@ -5,13 +5,13 @@ type: Configuration
 
 >**NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
 >
->This document is a ready-to-use template for the **Configuration** document type that provides technical details about configuration of a Kyma chart or sub-chart. Follow the `05-{00}-{component-name}.md` convention to name the document. Make sure that the configuration document for the main chart displays first on the list. If there is only one document of a certain type, remove the `type` metadata completely so that the document displays well on the UI. 
+>This document is a ready-to-use template for the **Configuration** document type that provides technical details about configuration of a Kyma chart or sub-chart. Follow the `05-{00}-{component-name}.md` convention to name the document. Make sure that the configuration document for the main chart displays first on the list. If there is only one document of a certain type, remove the `type` metadata completely so that the document displays well on the UI.
 
 To configure the {Component name} {sub-}chart, override the default values of its `values.yaml` file. This document describes parameters that you can configure.
 
 >Use the tip feature to provide links to the documentation about Kyma overrides. Also add a link to examples of either top-level charts overrides for charts configuration documents or sub-charts overrides for sub-chart configuration documents.
 
->**TIP:** To learn more about how to use overrides in Kyma, see the following documents: 
+>**TIP:** To learn more about how to use overrides in Kyma, see the following documents:
 >* [Helm overrides for Kyma installation](/root/kyma/#configuration-helm-overrides-for-kyma-installation)
 >* {[Top-level charts overrides](/root/kyma/#configuration-helm-overrides-for-kyma-installation-top-level-charts-overrides)}
 >* {[Sub-charts overrides](/root/kyma/#configuration-helm-overrides-for-kyma-installation-sub-chart-overrides)}
@@ -24,4 +24,4 @@ This table lists the configurable parameters, their descriptions, and default va
 |-----------|-------------|---------------|
 | **{parameter}** | {Parameter description} | `{parameter value}` |
 
-> For reference, see the existing **Configuration** documents for the [Asset Store](https://kyma-project.io/docs/master/components/asset-store/#configuration-configuration).
+> For reference, see the existing **Configuration** documents for the [Asset Store](https://kyma-project.io/docs/1.5/components/asset-store/#configuration-configuration).

--- a/guidelines/templates/resources/metrics.md
+++ b/guidelines/templates/resources/metrics.md
@@ -1,0 +1,31 @@
+---
+title: {Service/Controller name}
+type: Metrics
+---
+
+>**NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
+>
+>This document is a ready-to-use template for the **Metrics** document type that describes service or controller metrics. Follow the `14-{00}-{service-name}.md` convention to name the document.
+
+This table shows the {Service/Controller name} custom metrics, their types, and descriptions.
+
+| Name | Type | Description |
+|------|------|-------------|
+| `{metric_name}` | {metric_type} | {Metric description} |
+
+> If there are some default metrics, such as Prometheus metrics for [Go applications](https://prometheus.io/docs/guides/go-application/), exposed for the service or controller in addition to the custom ones, add this information to the document. For example, write:
+
+Apart from the custom metrics, the {Service/Controller name} also exposes default Prometheus metrics for [Go applications](https://prometheus.io/docs/guides/go-application/).
+
+> If you describe metrics for a service or a controller that does not expose any custom metrics, write only about the default ones. For example, write:
+
+Metrics for the {Service/Controller name} include:
+
+- {default metric name or description}.
+- {another default metric name or description}.
+
+> Provide a reference to the Monitoring documentation in Kyma.
+
+See the [Monitoring](/components/monitoring) documentation to learn more about monitoring and metrics in Kyma.
+
+> For reference, see the existing **Metrics** documents for the [Asset Store](https://kyma-project.io/docs/1.6/components/asset-store/#metrics-metrics).

--- a/guidelines/templates/resources/metrics.md
+++ b/guidelines/templates/resources/metrics.md
@@ -5,7 +5,7 @@ type: Metrics
 
 >**NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
 >
->This document is a ready-to-use template for the **Metrics** document type that describes service or controller metrics. Follow the `14-{00}-{service-name}.md` convention to name the document.
+>This document is a ready-to-use template for the **Metrics** document type that describes service or controller metrics. Follow the `14-{00}-{service/controller-name}.md` convention to name the document.
 
 This table shows the {Service/Controller name} custom metrics, their types, and descriptions.
 

--- a/guidelines/templates/resources/metrics.md
+++ b/guidelines/templates/resources/metrics.md
@@ -5,7 +5,7 @@ type: Metrics
 
 >**NOTE:** Blockquotes in this document provide instructions. Remove them from the final document.
 >
->This document is a ready-to-use template for the **Metrics** document type that describes service or controller metrics. Follow the `14-{00}-{service/controller-name}.md` convention to name the document.
+>This document is a ready-to-use template for the **Metrics** document type that describes service or controller metrics. Follow the `11-{00}-{service/controller-name}.md` convention to name the document.
 
 This table shows the {Service/Controller name} custom metrics, their types, and descriptions.
 

--- a/guidelines/templates/resources/metrics.md
+++ b/guidelines/templates/resources/metrics.md
@@ -7,7 +7,7 @@ type: Metrics
 >
 >This document is a ready-to-use template for the **Metrics** document type that describes service or controller metrics. Follow the `11-{00}-{service/controller-name}.md` convention to name the document.
 
-This table shows the {Service/Controller name} custom metrics, their types, and descriptions.
+This table shows the {Service name} custom metrics, their types, and descriptions.
 
 | Name | Type | Description |
 |------|------|-------------|
@@ -15,11 +15,11 @@ This table shows the {Service/Controller name} custom metrics, their types, and 
 
 > If there are some default metrics, such as Prometheus metrics for [Go applications](https://prometheus.io/docs/guides/go-application/), exposed for the service or controller in addition to the custom ones, add this information to the document. For example, write:
 
-Apart from the custom metrics, the {Service/Controller name} also exposes default Prometheus metrics for [Go applications](https://prometheus.io/docs/guides/go-application/).
+Apart from the custom metrics, the {Service name} also exposes default Prometheus metrics for [Go applications](https://prometheus.io/docs/guides/go-application/).
 
-> If you describe metrics for a service or a controller that does not expose any custom metrics, write only about the default ones. For example, write:
+> If you describe metrics for a controller that does not expose any custom metrics, write only about the default ones. For example, write:
 
-Metrics for the {Service/Controller name} include:
+Metrics for the {Controller name} include:
 
 - {default metric name or description}.
 - {another default metric name or description}.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Updated the content strategy document
- Add a template for the metrics docs type

**Related issue(s)**
Fixes kyma-project/kyma/issues/5826


