### PR TITLE
Unify backend and frontend naming in docs

### DIFF
--- a/capabilities/api-gateway.md
+++ b/capabilities/api-gateway.md
@@ -2,14 +2,14 @@
 displayName: "API Gateway"
 epicsLabels:
   - area/service-mesh
-  - quality/security 
-id: api-gateway 
+  - quality/security
+id: api-gateway
 ---
 
 ## Scope
 
 
-The API Gateway capability aims to provide a set of functionalities allowing developers to expose, secure and manage their API's in an easy way. 
+The API Gateway capability aims to provide a set of functionalities allowing developers to expose, secure and manage their API's in an easy way.
 Based on the Service Mesh capability, it provides a common way to plug in security (authorization & authentication), enable routing and accessibility for all created APIs.
 An API can be any application (lambda, GO application, etc.)
 
@@ -20,24 +20,24 @@ An API can be any application (lambda, GO application, etc.)
 
 * Extend authorization strategies for APIs
     * OAuth2 server issuing access tokens for exposed Kyma APIs (both user, and non-user oriented tokens)
-    * OAuth2 proxy securing exposed APIs in Kyma, allowing access based on issued access tokens 
+    * OAuth2 proxy securing exposed APIs in Kyma, allowing access based on issued access tokens
     * Enable [Open Policy Agent](https://www.openpolicyagent.org/) policies for authorization and admission control
-    * Support refreshing OAuth2 tokens	
-    
+    * Support refreshing OAuth2 tokens
+
 * Traffic management for APIs
     * Control outbound traffic for APIs - define a list of external services which the API can access
     * Control internal API traffic - specify which services can access APIs internally
     * Traffic management for different API versions - split traffic between different versions of one API
     * API failure prevention - enable setting circuit breakers for APIs
-      
+
 * Enable developers to create and expose APIs separated on the Namespace level
     * Allow applications to be exposed with Namespace name as a part of their hostname
     * Allow blocking communication between services living in different Namespaces
-    
-* Enable easy adoption of GraphQl in APIs 
-    * Allow legacy/microservice/serverless applications to be exposed and visible as GraphQl APIs 
-    * Automate configuration and deployment of front end proxies to allow communication using GraphQl
-  
+
+* Enable easy adoption of GraphQl in APIs
+    * Allow legacy/microservice/serverless applications to be exposed and visible as GraphQl APIs
+    * Automate configuration and deployment of frontend proxies to allow communication using GraphQl
+
 * Expose services running on different environments
     * Allow proxying requests to services running outside of Kyma - on Cloud Foundry, other Kubernetes clusters etc.
     * Allow configuring the same authentication and authorization policies as for services deployed in Kyma

--- a/capabilities/console-microfrontends.md
+++ b/capabilities/console-microfrontends.md
@@ -23,11 +23,10 @@ The Console/Microfrontends capability relates to the way in which a user interac
 
     * Use [Luigi orchestration framework](https://github.com/kyma-project/luigi) as UI extension mechanism to ease customization.
     * Compose user interfaces from modular and highly reusable UI components.
-    * Ensure consistent and correct usage of microfrontend-hosting.
+    * Ensure consistent and correct usage of micro frontend-hosting.
 
 * Fast & Responsive
-    
+
     * Quick loading time for user interfaces
     * Load only the essential data that is needed for rendering user interfaces and nothing more (use GraphQL).
     * Give the user feedback for his actions (use websockets).
-

--- a/collaboration/sig-core/decisions/dr-001-Technologies.md
+++ b/collaboration/sig-core/decisions/dr-001-Technologies.md
@@ -14,7 +14,7 @@ The Kyma developers need to select specific technologies. Their purpose is to:
 
 The decision is to use the **Go** language for all new implementations in Kyma. Go allows to create very efficient applications with low memory usage and a vast set of system libraries. Many projects which Kyma depends on are written in Go, including Kubernetes.
 
-Use the following front-end technologies within Kyma:
+Use the following frontend technologies within Kyma:
 
 * Open UI5
 * Angular (version 4 and later)

--- a/collaboration/sig-core/proposals/modularization.md
+++ b/collaboration/sig-core/proposals/modularization.md
@@ -23,7 +23,7 @@ The goal is to allow users to add, remove, and replace Kyma components in more f
 - Install Kyma as Gardener add-on with dependencies to Istio and Knative add-ons.
 - Add a Service Broker to existing Kyma installation in runtime, for example Azure Broker.
 - Add a new Remote Environment (also new type of application) in runtime.
-- Add completely new Kyma component that integrates with UI in runtime (register micro front-end and custom resources).
+- Add completely new Kyma component that integrates with UI in runtime (register micro frontend and custom resources).
 - Use user provided S3 bucket instead of Minio.
 - Install private modules (from private Docker registry or private Git repository).
 - Install components from Kyma examples and showcases catalog easily (UI).
@@ -50,7 +50,7 @@ The proposed solution is to provide a flexible and modular installation of fine 
 - Parameters should not be hard-coded - there should be a convention on how to pass the parameters through the installation process to the Kyma components.
 - Default values everywhere - the list of mandatory parameters should be as short as possible. The goal is to have only the cluster domain as a mandatory parameter.
 - Optional dependencies, for example: Kyma ui-api-layer can work without custom resources introduced by the Service Catalog or Remote Environment and still can support other areas.
-- Dynamic UI (micro front-ends) + back-end - adding new components extends views and also the backed functionalities, such as the supported GraphQL queries.
+- Dynamic UI (micro frontends) + back-end - adding new components extends views and also the backed functionalities, such as the supported GraphQL queries.
 - No custom logic in the installation process (shell scripts) - it should be replaced by the operator pattern.
 - The minimal set of mandatory components that form the real Kyma "core". The dependency for the core can be mandatory, other dependencies should be optional.
 - Kyma core as Gardener add-on. For reference, see [Knative with Gardener](https://github.com/knative/docs/blob/master/docs/install/Knative-with-Gardener.md) and [Gardener Bouquet](https://github.com/gardener/bouquet) documentation.
@@ -72,4 +72,3 @@ This [project](https://github.com/PK85/kyma-bundles):
 - Gives you a one-step Helm Broker repository configuration update in your Kubernetes cluster.
 
 ![](assets/modularization-bundles.svg)
-

--- a/collaboration/sig-core/proposals/ui-api-layer-modularization.md
+++ b/collaboration/sig-core/proposals/ui-api-layer-modularization.md
@@ -58,7 +58,7 @@ spec:
 
 The only required field is the unique name of the resource.
 
-Extending the existing custom resources, `Microfrontend` and `ClusterMicrofrontend`, has been considered. If the `(Cluster)Microfrontend` resource had references to the required UI API Layer modules, then we cannot make sure that the Kyma component is actually installed. There could be microfrontends that depend on two components. If just one of them is not installed, it would result in an error/crash.
+Extending the existing custom resources, `Microfrontend` and `ClusterMicrofrontend`, has been considered. If the `(Cluster)Microfrontend` resource had references to the required UI API Layer modules, then we cannot make sure that the Kyma component is actually installed. There could be micro frontends that depend on two components. If just one of them is not installed, it would result in an error/crash.
 
 On the other hand, combining two ideas together, `ConsoleBackendModule` and relation in `(Cluster)Microfrontend` to `ConsoleBackendModule`, would be too complicated.
 
@@ -85,4 +85,4 @@ On the other hand, combining two ideas together, `ConsoleBackendModule` and rela
 
 ### Proof of Concept
 
-The PoC has been created in [PR #1849](https://github.com/kyma-project/kyma/pull/1849/files) for the Kyma repository. It contains a pluggable `k8s` domain as an example. The PoC uses `Module`, an outdated name of the Custom Resource. 
+The PoC has been created in [PR #1849](https://github.com/kyma-project/kyma/pull/1849/files) for the Kyma repository. It contains a pluggable `k8s` domain as an example. The PoC uses `Module`, an outdated name of the Custom Resource.

--- a/guidelines/content-guidelines/05-links.md
+++ b/guidelines/content-guidelines/05-links.md
@@ -31,7 +31,7 @@ If the `{type}` doesn't exist, the pattern has the form of `#{title}-{title}-{he
 
 ### Links to the assets folder
 
-To add a reference to a YAML, JSON, SVG, PNG, or JPG file located in the `assets` folder in the same topic, use GitHub relative links. For example, write `[Here](./assets/mf-namespaced.yaml) you can find a sample micro front-end entity.` When you click such a link on the `kyma-project.io` website, it opens the file content in the same tab.
+To add a reference to a YAML, JSON, SVG, PNG, or JPG file located in the `assets` folder in the same topic, use GitHub relative links. For example, write `[Here](./assets/mf-namespaced.yaml) you can find a sample micro frontend entity.` When you click such a link on the `kyma-project.io` website, it opens the file content in the same tab.
 
 ## Links between documents in different topics
 


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Unified backend and frontend naming in docs

**Related issue(s)**
See also #https://github.com/kyma-project/kyma/issues/2225


