### PR TITLE
Update guidelines with info on alt text

### DIFF
--- a/guidelines/content-guidelines/02-diagrams.md
+++ b/guidelines/content-guidelines/02-diagrams.md
@@ -11,7 +11,7 @@ To convey the intended message effectively in a diagram, follow these basic prin
 
 For details on how to format diagrams and their elements in Kyma documents, see the particular document sections.
 
-## Descriptions
+## Alternative text
 
 Always add an alternative (alt) text that concisely describes the content or function of the diagram you are referring to. The alt text:
 

--- a/guidelines/content-guidelines/02-diagrams.md
+++ b/guidelines/content-guidelines/02-diagrams.md
@@ -15,7 +15,7 @@ For details on how to format diagrams and their elements in Kyma documents, see 
 
 Always add an alternative text that concisely describes the content or function of the diagram you are referring to. The alt text:
 
-- Helps to maintain accessibility for every visitor (including people with vision impairments).
+- Helps to maintain accessibility for every visitor, including people with vision impairments.
 - Appears in place of a diagram if it fails to load.
 - Improves the SEO of the website by enabling crawlers to index the diagram contents better.
 

--- a/guidelines/content-guidelines/02-diagrams.md
+++ b/guidelines/content-guidelines/02-diagrams.md
@@ -19,8 +19,8 @@ Always add an alternative text that concisely describes the content or function 
 - Appears in place of a diagram if it fails to load.
 - Improves the SEO of the website by enabling crawlers to index the diagram contents better.
 
-    ⛔️ `![](./assets/create-bucket.svg)` 
-    ✅ `![Create a bucket](./assets/create-bucket.svg)`
+    ⛔️ `![](./assets/create-bucket.svg)`  
+    ✅ `![Create a bucket](./assets/create-bucket.svg)`  
 
 ## Tool
 

--- a/guidelines/content-guidelines/02-diagrams.md
+++ b/guidelines/content-guidelines/02-diagrams.md
@@ -11,6 +11,17 @@ To convey the intended message effectively in a diagram, follow these basic prin
 
 For details on how to format diagrams and their elements in Kyma documents, see the particular document sections.
 
+## Reference
+
+Always add an alternative text that concisely describes the content or function of the diagram you are referring to. The alt text:
+
+- Helps to maintain accessibility for every visitor (including people with vision impairments).
+- Appears in place of a diagram if it fails to load.
+- Improves the SEO of the website by enabling crawlers to index the diagram contents better.
+
+    ⛔️ `![](./assets/create-bucket.svg)`
+    ✅ `![Create a bucket](./assets/create-bucket.svg)`
+
 ## Tool
 
 Use [draw.io](https://www.draw.io) as a recommended tool. Export the diagram as an SVG and save it under the corresponding `assets` directory.
@@ -19,7 +30,7 @@ Use [draw.io](https://www.draw.io) as a recommended tool. Export the diagram as 
 
 Keep your diagram reasonable in size. Preview the image at full size to see how it fits into the whole document. The diagram should be large enough to be legible and convey the intended message, but should not dominate the whole document. To demonstrate large concepts, simplify the diagram or divide it into a few smaller ones.
 
->**NOTE:** The diagrams keep their original aspect ratio on both the Console UI and the `kyma-project.io` website. However, the maximum width on the website is 860px. Any diagram that exceeds that limit is resized to the maximum width. 
+>**NOTE:** The diagrams keep their original aspect ratio on both the Console UI and the `kyma-project.io` website. However, the maximum width on the website is 860px. Any diagram that exceeds that limit is resized to the maximum width.
 
 ## Background
 

--- a/guidelines/content-guidelines/02-diagrams.md
+++ b/guidelines/content-guidelines/02-diagrams.md
@@ -19,7 +19,7 @@ Always add an alternative text that concisely describes the content or function 
 - Appears in place of a diagram if it fails to load.
 - Improves the SEO of the website by enabling crawlers to index the diagram contents better.
 
-    ⛔️ `![](./assets/create-bucket.svg)`
+    ⛔️ `![](./assets/create-bucket.svg)` 
     ✅ `![Create a bucket](./assets/create-bucket.svg)`
 
 ## Tool

--- a/guidelines/content-guidelines/02-diagrams.md
+++ b/guidelines/content-guidelines/02-diagrams.md
@@ -11,9 +11,9 @@ To convey the intended message effectively in a diagram, follow these basic prin
 
 For details on how to format diagrams and their elements in Kyma documents, see the particular document sections.
 
-## Reference
+## Descriptions
 
-Always add an alternative text that concisely describes the content or function of the diagram you are referring to. The alt text:
+Always add an alternative (alt) texts that concisely describes the content or function of the diagram you are referring to. The alt text:
 
 - Helps to maintain accessibility for every visitor, including people with vision impairments.
 - Appears in place of a diagram if it fails to load.

--- a/guidelines/content-guidelines/02-diagrams.md
+++ b/guidelines/content-guidelines/02-diagrams.md
@@ -13,7 +13,7 @@ For details on how to format diagrams and their elements in Kyma documents, see 
 
 ## Descriptions
 
-Always add an alternative (alt) texts that concisely describes the content or function of the diagram you are referring to. The alt text:
+Always add an alternative (alt) text that concisely describes the content or function of the diagram you are referring to. The alt text:
 
 - Helps to maintain accessibility for every visitor, including people with vision impairments.
 - Appears in place of a diagram if it fails to load.

--- a/guidelines/content-guidelines/07-screenshots.md
+++ b/guidelines/content-guidelines/07-screenshots.md
@@ -17,7 +17,7 @@ For details on how to format screenshots and their elements in Kyma documents, s
 
 Always add an alternative text that concisely describes the content or function of the image you are referring to. The alt text:
 
-- Helps to maintain accessibility for every visitor (including people with vision impairments).
+- Helps to maintain accessibility for every visitor, including people with vision impairments.
 - Appears in place of an image if it fails to load.
 - Improves the SEO of the website by enabling crawlers to index the image contents better.
 

--- a/guidelines/content-guidelines/07-screenshots.md
+++ b/guidelines/content-guidelines/07-screenshots.md
@@ -21,7 +21,7 @@ Always add an alternative text that concisely describes the content or function 
 - Appears in place of an image if it fails to load.
 - Improves the SEO of the website by enabling crawlers to index the image contents better.
 
-    ⛔️ `![](./assets/create-bucket.png)`
+    ⛔️ `![](./assets/create-bucket.png)` 
     ✅ `![Create a bucket](./assets/create-bucket.png)`
 
 ## Tool

--- a/guidelines/content-guidelines/07-screenshots.md
+++ b/guidelines/content-guidelines/07-screenshots.md
@@ -13,9 +13,9 @@ Follow these basic principles when you place screenshots in your content:
 
 For details on how to format screenshots and their elements in Kyma documents, see the particular document sections.
 
-## Reference
+## Descriptions
 
-Always add an alternative text that concisely describes the content or function of the image you are referring to. The alt text:
+Always add an alternative (alt) text that concisely describes the content or function of the image you are referring to. The alt text:
 
 - Helps to maintain accessibility for every visitor, including people with vision impairments.
 - Appears in place of an image if it fails to load.

--- a/guidelines/content-guidelines/07-screenshots.md
+++ b/guidelines/content-guidelines/07-screenshots.md
@@ -21,8 +21,8 @@ Always add an alternative text that concisely describes the content or function 
 - Appears in place of an image if it fails to load.
 - Improves the SEO of the website by enabling crawlers to index the image contents better.
 
-    ⛔️ `![](./assets/create-bucket.png)` 
-    ✅ `![Create a bucket](./assets/create-bucket.png)`
+    ⛔️ `![](./assets/create-bucket.png)`  
+    ✅ `![Create a bucket](./assets/create-bucket.png)`  
 
 ## Tool
 

--- a/guidelines/content-guidelines/07-screenshots.md
+++ b/guidelines/content-guidelines/07-screenshots.md
@@ -5,6 +5,7 @@ title: Screenshots
 As someone once said, a picture is worth a thousand words. Therefore, whenever you need to illustrate operations performed on the UI, use a screenshot to convey the information visually.
 
 Follow these basic principles when you place screenshots in your content:
+
 - Do not overuse screenshots and limit visual noise.
 - Do not use directional indicators such as "above" and "below" to refer to screenshots. Instead, include a brief introduction before each screenshot that describes its purpose and any necessary details.
 - Do not include the mouse pointer in your screenshots, unless it shows a function related to the content.
@@ -12,13 +13,24 @@ Follow these basic principles when you place screenshots in your content:
 
 For details on how to format screenshots and their elements in Kyma documents, see the particular document sections.
 
+## Reference
+
+Always add an alternative text that concisely describes the content or function of the image you are referring to. The alt text:
+
+- Helps to maintain accessibility for every visitor (including people with vision impairments).
+- Appears in place of an image if it fails to load.
+- Improves the SEO of the website by enabling crawlers to index the image contents better.
+
+    ⛔️ `![](./assets/create-bucket.png)`
+    ✅ `![Create a bucket](./assets/create-bucket.png)`
+
 ## Tool
 
 Adjust or capture your screenshots using any tool that outputs high quality images, such as [Snagit](https://www.techsmith.com/screen-capture.html), [Lightshot](https://app.prntscr.com), or [Monosnap](https://www.monosnap.com/welcome). The desired image format is SVG, but PNG and JPG formats are also acceptable.
 Use an online tool such as [TinyPNG](https://tinypng.com/) to compress images and limit the size of each image to 1MB, or smaller.
 If you want to control the size of the image relative to the screen size, use one of these standard percentages: 100%, 75%, 50%, or 25%.
 
->**NOTE:** The images keep their original aspect ratio on both the Console UI and the `kyma-project.io` website. However, the maximum width on the website is 860px. Any image that exceeds that limit is resized to the maximum width. 
+>**NOTE:** The images keep their original aspect ratio on both the Console UI and the `kyma-project.io` website. However, the maximum width on the website is 860px. Any image that exceeds that limit is resized to the maximum width.
 
 Name the file as `{screenshot-name}` and save it under the corresponding `assets` directory.
 

--- a/guidelines/content-guidelines/07-screenshots.md
+++ b/guidelines/content-guidelines/07-screenshots.md
@@ -13,7 +13,7 @@ Follow these basic principles when you place screenshots in your content:
 
 For details on how to format screenshots and their elements in Kyma documents, see the particular document sections.
 
-## Descriptions
+## Alternative text
 
 Always add an alternative (alt) text that concisely describes the content or function of the image you are referring to. The alt text:
 


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Updated guidelines with info on obligatory alt text for screenshots and diagrams in docs.

**Related issue(s)**
See also https://github.com/kyma-project/kyma/issues/8464.


