### PR TITLE
Add content guidelines on formatting rights as code and spelling cloud-native (adjective)

### DIFF
--- a/guidelines/content-guidelines/04-formatting.md
+++ b/guidelines/content-guidelines/04-formatting.md
@@ -34,7 +34,8 @@ Status and error codes    | A successful response includes a status code of `200
 Parameter and value pairs | The controller adds the `env=true` label to all newly created Namespaces.
 Metadata names            | When you create a Markdown document, define its `title` and `type`.
 Flags                     | Add the `--tls` flag to every Helm command you run.
-GraphQL queries and mutations   | The `requestOneTimeTokenForApplication` mutation calls the internal GraphQL API to get a one-time token.
+GraphQL queries and mutations   | The `requestOneTimeTokenForApplication` mutation calls the internal GraphQL API to get a one-time token. |
+Rights                    | The preset gives multiple resource cleaners the `list` and `delete` rights in GCP.
 
 >**NOTE:** When you mention specific configuration files in your documents, consider linking to them instead of just mentioning their names. When you link to a file, use its name without the format extension. See the following example:
 > `To adjust the number of Pods in your Deployment, edit the [deployment](./deployment.yaml) file.`

--- a/guidelines/content-guidelines/08-style-and-terminology.md
+++ b/guidelines/content-guidelines/08-style-and-terminology.md
@@ -110,8 +110,9 @@ Don't use "e.g." in documentation. Use the words "for example" or "such as" inst
 * "run," not "execute"
 * "API Micro Gateway," not "API Gateway"
 * "connect/connection," not "integrate/integration"
-* "custom resource," not "Custom Resource" or "CustomResource"
+* "custom resource," not "Custom Resource" nor "CustomResource"
 * "Application" to describe an external solution connected to Kyma through the Application Connector, "application" to describe software
+* "cloud-native" (adjective), not "cloud native"
 
 > **NOTE:** Do not use words such as "currently" or "now" to indicate that something is in the transitional phase of development. Avoid promising anything and mention only those components and functionalities that are already in use.
 


### PR DESCRIPTION
**Description**

See the related issue for more details.

Changes proposed in this pull request:

- Add guidelines on formatting rights as `code` and provide an example
- Add guidelines on spelling `cloud-native` with the hyphen when used as an adjective

**Related issue**
#480 