### PR TITLE
Update codeowners

### DIFF
--- a/.kyma-project-io/build-preview.sh
+++ b/.kyma-project-io/build-preview.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Script for build preview of this repo like in https://kyma-project.io/community/ on every PR.
-# For more information, please contact with: @michal-hudy @m00g3n @aerfio @magicmatatjahu
+# For more information, please contact with: @m00g3n @aerfio @magicmatatjahu
 
 set -eo pipefail
 
@@ -42,7 +42,7 @@ copy-website-repo() {
 }
 
 build-preview() {
-  export PREVIEW_SOURCE_DIR="${KYMA_PROJECT_IO_DIR}/.." 
+  export PREVIEW_SOURCE_DIR="${KYMA_PROJECT_IO_DIR}/.."
   make -C "${BUILD_DIR}" netlify-community-preview
 }
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,17 +1,17 @@
 # Default owners of the repository
-* @kazydek @klaudiagrz @tomekpapiernik @bszwarc @mmitoraj @majakurcius @alexandra-simeonova
+* @kazydek @klaudiagrz @bszwarc @mmitoraj @majakurcius @alexandra-simeonova
 
 # Owners of the manifesto-app folder
-/manifesto-app/ @michal-hudy @m00g3n @aerfio @magicmatatjahu
+/manifesto-app/ @m00g3n @aerfio @magicmatatjahu
 
 # Owners of the collaboration folder
 /collaboration/ @PK85 @mszostok
 
 # Owners of all .md files in the repository
-*.md @kazydek @klaudiagrz @tomekpapiernik @bszwarc @mmitoraj @majakurcius @alexandra-simeonova
+*.md @kazydek @klaudiagrz @bszwarc @mmitoraj @majakurcius @alexandra-simeonova
 
 # Owners of the .kyma-project-io folder
-/.kyma-project-io/ @michal-hudy @m00g3n @aerfio @magicmatatjahu
+/.kyma-project-io/ @m00g3n @aerfio @magicmatatjahu
 
 # Owners of config file for MILV - milv.config.yaml
-milv.config.yaml @michal-hudy @m00g3n @aerfio @magicmatatjahu
+milv.config.yaml @m00g3n @aerfio @magicmatatjahu

--- a/capabilities/README.md
+++ b/capabilities/README.md
@@ -13,8 +13,8 @@ This table lists all capabilities and links to their descriptions.
 | [API Gateway](api-gateway.md)| [@piotrmsc](https://github.com/piotrmsc) |
 | [Application Connectivity](application-connectivity.md) | [@janmedrek](https://github.com/janmedrek) |
 | [Console / Microfrontends](console-microfrontends.md) | [@kwiatekus](https://github.com/kwiatekus) |
-| [Core & Supporting](core-and-supporting.md) | [@michal-hudy](https://github.com/michal-hudy) |
+| [Core & Supporting](core-and-supporting.md) | [@kwiatekus](https://github.com/kwiatekus) |
 | [Eventing](eventing.md) | [@anishj0shi](https://github.com/anishj0shi) |
 | [Logging / Tracing / Monitoring](logging-tracing-monitoring.md) | [@a-thaler](https://github.com/a-thaler) |
-| [Serverless Runtime](runtime.md) | [@michal-hudy](https://github.com/michal-hudy) |
+| [Serverless Runtime](runtime.md) | [@kwiatekus](https://github.com/kwiatekus) |
 | [Service Management](service-management.md) | [@PK85](https://github.com/PK85) |


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

In recent months, Paweł Kosiec, Adam Szecówka, Tomek Papiernik and Michał Hudy left the company. According to the [offboarding guidelines](https://kyma-project.io/community/governance#kyma-working-model-kyma-working-model-when-does-a-maintainer-lose-the-maintainer-status), a person should be removed from codeowners in case they are no longer interested in contributing or haven't contributed to the project for more than 3 months. As for the persons mentioned above, the following reasons occurred:

- After consulting Paweł and Tomek, I've learned that they are no longer interested in contributing to the project.
- Adam has been inactive for more than 3 months.
- Michał has changed his GitHub login and thus the old one should be removed from all the codeowners files. His new login is already mentioned in the [emeritus file](https://github.com/kyma-project/community/blob/master/emeritus.md).

Changes proposed in this pull request:

- Remove `pkosiec` from codeowners
- Remove `aszecowka` from codeowners
- Remove `tomekpapiernik` from codeowners
- Remove `michal-hudy` from codeowners

**Related issue(s)**
[#50](https://github.tools.sap/kyma/community/issues/50)