### PR TITLE
Add the alternative draw.io name

### DIFF
--- a/guidelines/content-guidelines/02-diagrams.md
+++ b/guidelines/content-guidelines/02-diagrams.md
@@ -24,7 +24,7 @@ Always add an alternative (alt) text that concisely describes the content or fun
 
 ## Tool
 
-Use [draw.io](https://www.draw.io) (aka [diagrams.net](https://(www.diagrams.net/index.html)) as a recommended tool. Export the diagram as an SVG and save it under the corresponding `assets` directory.
+Use [draw.io](https://www.draw.io) (aka [diagrams.net](www.diagrams.net/index.html)) as a recommended tool. Export the diagram as an SVG and save it under the corresponding `assets` directory.
 
 ## Size
 

--- a/guidelines/content-guidelines/02-diagrams.md
+++ b/guidelines/content-guidelines/02-diagrams.md
@@ -24,7 +24,7 @@ Always add an alternative (alt) text that concisely describes the content or fun
 
 ## Tool
 
-Use [draw.io](https://www.draw.io) as a recommended tool. Export the diagram as an SVG and save it under the corresponding `assets` directory.
+Use [draw.io](https://www.draw.io) (aka [diagrams.net](https://(www.diagrams.net/index.html)) as a recommended tool. Export the diagram as an SVG and save it under the corresponding `assets` directory.
 
 ## Size
 

--- a/guidelines/content-guidelines/02-diagrams.md
+++ b/guidelines/content-guidelines/02-diagrams.md
@@ -24,7 +24,7 @@ Always add an alternative (alt) text that concisely describes the content or fun
 
 ## Tool
 
-Use [draw.io](https://www.draw.io) (aka [diagrams.net](https://www.diagrams.net/index.html)) as a recommended tool. Export the diagram as an SVG and save it under the corresponding `assets` directory.
+Use [draw.io](https://www.draw.io) or [diagrams.net](https://www.diagrams.net/index.html) as a recommended tool. Export the diagram as an SVG and save it under the corresponding `assets` directory.
 
 ## Size
 

--- a/guidelines/content-guidelines/02-diagrams.md
+++ b/guidelines/content-guidelines/02-diagrams.md
@@ -24,7 +24,7 @@ Always add an alternative (alt) text that concisely describes the content or fun
 
 ## Tool
 
-Use [draw.io](https://www.draw.io) (aka [diagrams.net](www.diagrams.net/index.html)) as a recommended tool. Export the diagram as an SVG and save it under the corresponding `assets` directory.
+Use [draw.io](https://www.draw.io) (aka [diagrams.net](https://www.diagrams.net/index.html)) as a recommended tool. Export the diagram as an SVG and save it under the corresponding `assets` directory.
 
 ## Size
 


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Add [`www.diagrams.net`](https://www.diagrams.net/index.html) as an alternative name for `draw.io`.

**Reasons**
The [blog post](https://www.diagrams.net/blog/move-diagrams-net) indicating the domain change.



