### PR TITLE
Add Service to the capitalized k8s-related terms in the guidelines

### DIFF
--- a/guidelines/content-guidelines/08-style-and-terminology.md
+++ b/guidelines/content-guidelines/08-style-and-terminology.md
@@ -147,6 +147,7 @@ This is the list of the Kubernetes resources capitalized in Kyma documentation. 
 - Pod
 - ProwJob
 - Secret
+- Service
 - ServiceBinding
 - ServiceClass
 - ServiceInstance


### PR DESCRIPTION
**Description**

Since we mention `Service` in terms of a Kubernetes resource a lot throughout our documentation, but we also write about different services in general, we should explicitly add the spelling of this term to our content guidelines so it's not confused.

Changes proposed in this pull request:

- Add `Service` to the list of capitalized Kubernetes-related resources.
