### PR TITLE
Update emeritus file

### DIFF
--- a/emeritus.md
+++ b/emeritus.md
@@ -3,6 +3,6 @@ This file lists all maintainers that are no longer actively contributing to the 
 * Łukasz Górnicki (**[@derberg](https://github.com/derberg)**) involved in `area/core-and-supporting` and the overall Kyma architecture.
 * Michał Hudy (**[@hudymi](https://github.com/hudymi)**) involved in `area/core-and-supporting`, `area/serverless`, and the overall Kyma architecture.
 * Adam Szecówka (**[@aszecowka](https://github.com/aszecowka)**) involved in `area/service-catalog`, `area/ci`, `area/quality`, and `area/management-plane`.
-* Paweł Kosiec (**[@pkosiec](https://github.com/pkosiec)**) involved in `area/core-and-supporting`, `area/console`, `area/management-plane` and `area/control-plane`.
-* Tomasz Papiernik (**[@tomekpapiernik](https://github.com/tomekpapiernik)**) involved in `area/documentation`.
-* Barbara Czyż (**[@bszwarc](https://github.com/bszwarc)**) involved in `area/documentation`. 
+* Paweł Kosiec (**[@pkosiec](https://github.com/pkosiec)**) involved in `area/core-and-supporting`, `area/console`, `area/management-plane`, and `area/control-plane`.
+* Tomasz Papiernik (**[@tomekpapiernik](https://github.com/tomekpapiernik)**) involved in `area/documentation` and creating docs for `area/service-mesh`, `area/installation`, and `area/api-gateway`.
+* Barbara Czyż (**[@bszwarc](https://github.com/bszwarc)**) involved in `area/documentation` and creating docs for `area/eventing`, `area/logging`, `area/monitoring`, and `area/cli`.

--- a/emeritus.md
+++ b/emeritus.md
@@ -5,4 +5,4 @@ This file lists all maintainers that are no longer actively contributing to the 
 * Adam Szecówka (**[@aszecowka](https://github.com/aszecowka)**) involved in `area/service-catalog`, `area/ci`, `area/quality`, and `area/management-plane`.
 * Paweł Kosiec (**[@pkosiec](https://github.com/pkosiec)**) involved in `area/core-and-supporting`, `area/console`, `area/management-plane` and `area/control-plane`.
 * Tomasz Papiernik (**[@tomekpapiernik](https://github.com/tomekpapiernik)**) involved in `area/documentation`.
-* Barbara Czyż (**[@bszwarc](https://github.com/bszwarc)**) involved in `area/documentation`, `area/blob-discovery`.
+* Barbara Czyż (**[@bszwarc](https://github.com/bszwarc)**) involved in `area/documentation`. 

--- a/emeritus.md
+++ b/emeritus.md
@@ -1,7 +1,8 @@
 This file lists all maintainers that are no longer actively contributing to the project. These people may be domain experts over certain areas of the codebase, but can no longer dedicate the time needed to handle the responsibilities of reviewing and approving changes.
 
-* Łukasz Górnicki (**[@derberg](https://github.com/derberg)**) involved in `area/core-and-supporting` and the overall Kyma architecture
-* Michał Hudy (**[@hudymi](https://github.com/hudymi)**) involved in `area/core-and-supporting`, `area/serverless`, and the overall Kyma architecture
+* Łukasz Górnicki (**[@derberg](https://github.com/derberg)**) involved in `area/core-and-supporting` and the overall Kyma architecture.
+* Michał Hudy (**[@hudymi](https://github.com/hudymi)**) involved in `area/core-and-supporting`, `area/serverless`, and the overall Kyma architecture.
 * Adam Szecówka (**[@aszecowka](https://github.com/aszecowka)**) involved in `area/service-catalog`, `area/ci`, `area/quality`, and `area/management-plane`.
 * Paweł Kosiec (**[@pkosiec](https://github.com/pkosiec)**) involved in `area/core-and-supporting`, `area/console`, `area/management-plane` and `area/control-plane`.
 * Tomasz Papiernik (**[@tomekpapiernik](https://github.com/tomekpapiernik)**) involved in `area/documentation`.
+* Barbara Czyż (**[@bszwarc](https://github.com/bszwarc)**) involved in `area/documentation`, `area/blob-discovery`.


### PR DESCRIPTION

**Description**

As described in the governance model, the name of the former maintainer should be added to the emeritus file with short info about what areas were covered by this person.
