### PR TITLE
Remove @mszostok from CODEOWNERS and add him to emeritus

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 /manifesto-app/ @m00g3n @aerfio @magicmatatjahu
 
 # Owners of the collaboration folder
-/collaboration/ @PK85 @mszostok
+/collaboration/ @PK85
 
 # Owners of all .md files in the repository
 *.md @kazydek @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @superojla

--- a/emeritus.md
+++ b/emeritus.md
@@ -7,3 +7,4 @@ This file lists all maintainers that are no longer actively contributing to the 
 * Tomasz Papiernik (**[@tomekpapiernik](https://github.com/tomekpapiernik)**) involved in `area/documentation` and creating docs for `area/service-mesh`, `area/installation`, and `area/api-gateway`.
 * Barbara Czyż (**[@bszwarc](https://github.com/bszwarc)**) involved in `area/documentation` and creating docs for `area/eventing`, `area/logging`, `area/monitoring`, and `area/cli`.
 * Maciej Urbańczyk (**[@magicmatatjahu](https://github.com/magicmatatjahu)**) involved in `area/core-and-supporting`, `area/serverless`, and `area/console`.
+* Mateusz Szostok (**[@mszostok](https://github.com/mszostok)**) involved in `area/service-catalog`, `area/quality`, and `area/management-plane`, and `area/control-plane`.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/master/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/master/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Mateusz left Kyma in August and has not continued contributing to our project since then. According to the [offboarding guidelines](https://kyma-project.io/community/governance#kyma-working-model-kyma-working-model-when-does-a-maintainer-lose-the-maintainer-status), a person should be removed from codeowners in case they are no longer interested in contributing or haven't contributed to the project for more than 3 months. 

Changes proposed in this pull request:

- Remove @mszostok from CODEOWNERS
- Add Mateusz to the emeritus file

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->


