### PR TITLE
Change log levels on stage and prod

### DIFF
--- a/internal/proposals/logs/unified-approach-to-logging-levels.md
+++ b/internal/proposals/logs/unified-approach-to-logging-levels.md
@@ -21,8 +21,8 @@ No other severity will be used as it is not needed. Note that every further log 
 
 To be consistent, we need to agree on what default level components will log in each environment:
 
-- PROD: `WARN` - this is a minimal severity needed for effective debugging of issues,
-- STAGE: `WARN` - this is a minimal severity needed for effective debugging of issues. It'd also be a good indicator on how the logs will look like on PROD environment,
+- PROD: `INFO` - this is a minimal severity needed for effective debugging of issues,
+- STAGE: `INFO` - this is a minimal severity needed for effective debugging of issues. It'd also be a good indicator on how the logs will look like on PROD environment,
 - DEV: `DEBUG` - this is a lowest possible logging level. It may be helpful for debugging issues while developing.
 
 In the current state we log everything on every environment. Therefore, changing the logs severity could only decrease amount of the logs on some environments, and there is no need to increase the amount of needed resources for our components. A potential amount of the resources decreasement could be done during the next iteration of evaluating the Kyma profiles.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/master/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/master/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
 - change the default log level for PROD and STAGE environment

Reason:
Usually we are looking at logs when something goes wrong or seems to be working wrong. Without INFO we are not able to see what was before, we do not see the history.
On the other hand there are some situations where somebody claims that our service is not working correctly. Without any logs it is hard to verify it.

If INFO logs take too much space - think about changing the level of some logs to DEBUG.


