### PR TITLE
Add the link to the OS Kyma Slack to Ignored to stop false 404s

### DIFF
--- a/milv.config.yaml
+++ b/milv.config.yaml
@@ -1,5 +1,5 @@
 external-links-to-ignore: ["localhost", "kyma.local", "kyma-system"]
-internal-links-to-ignore: ["mailto:kyma-security@googlegroups.com"]
+internal-links-to-ignore: ["mailto:kyma-security@googlegroups.com", "http://slack.kyma-project.io", "http://slack.kyma-project.io/"]
 files-to-ignore: ["/templates/","-template.md", "/.kyma-project-io/", "/collaboration/", "/contributing/", "/governance/", "/guidelines/content-guidelines/", "/guidelines/releases-guidelines/", "/guidelines/repository-guidelines/", "/guidelines/technical-guidelines/", "/guidelines/templates/README.md", "/guidelines/templates/templates-type.md"]
 timeout: 60
 request-repeats: 5


### PR DESCRIPTION
The link to the OS Kyma Slack channel (http://slack.kyma-project.io) has recently started returning the `404 Not Found` error for MILV, but the link in fact works, therefore it needs to be added to the Ignored list for now to get rid of those false 404s.

**Description**

Changes proposed in this pull request:

- Add `http://slack.kyma-project.io` to the Ignored list for MILV.

**Related issue(s)**
https://github.com/kyma-incubator/milv/issues/12
