### PR TITLE
Move links to ignore to proper list

### DIFF
--- a/milv.config.yaml
+++ b/milv.config.yaml
@@ -1,5 +1,5 @@
-external-links-to-ignore: ["localhost", "kyma.local", "kyma-system"]
-internal-links-to-ignore: ["mailto:kyma-security@googlegroups.com", "http://slack.kyma-project.io", "http://slack.kyma-project.io/"]
+external-links-to-ignore: ["localhost", "kyma.local", "kyma-system", "http://slack.kyma-project.io", "http://slack.kyma-project.io/"]
+internal-links-to-ignore: ["mailto:kyma-security@googlegroups.com"]
 files-to-ignore: ["/templates/","-template.md", "/.kyma-project-io/", "/collaboration/", "/contributing/", "/governance/", "/guidelines/content-guidelines/", "/guidelines/releases-guidelines/", "/guidelines/repository-guidelines/", "/guidelines/technical-guidelines/", "/guidelines/templates/README.md", "/guidelines/templates/templates-type.md"]
 timeout: 60
 request-repeats: 5


### PR DESCRIPTION
**Description**

The external links were mistakenly put in the Internal Links to Ignore List. 
This PR puts them in the External Links list. 

Changes proposed in this pull request:

- Move OS Kyma Slack links to ignore to the External Links to Ignore list

**Related issue(s)**
#596 
