### PR TITLE
Update the codeowners procedure

### DIFF
--- a/docs/governance/01-governance.md
+++ b/docs/governance/01-governance.md
@@ -51,7 +51,7 @@ Every codeowner is expected to:
   of the existing maintainers.
 * We may ask you to do some PRs from our backlog.
 * As you gain experience with the code base and our standards, we will ask you to do code reviews for incoming PRs (i.e., all maintainers are expected to shoulder a proportional share of community reviews).
-* After a period of approximately 3 months of working together and making sure we see eye to eye, a candidate for maintainer should create an issue in the [community](https://github.com/kyma-project/community) repository with a list of his/her current contributions. The existing maintainers will confer and decide whether to grant the maintainer status or not. While we make no guarantees on the length of time this will take, we expect it to be no longer than 3 months.
+* After working together and making sure you deeply understand the code base, and are comfortable with submitting reviews, the existing codeowners can make a decision to add you to the maintainers list. A candidate for maintainer should create an issue in the [community](https://github.com/kyma-project/community) repository with a list of his/her current contributions. The existing maintainers will confer and decide whether to grant the maintainer status or not.
 
 >**NOTE:** To be accepted as a maintainer and be added to Kyma GitHub organizations, you need to have [two-factor authentication](https://help.github.com/en/articles/about-two-factor-authentication) enabled on your GitHub account.
 
@@ -59,7 +59,7 @@ Every codeowner is expected to:
 
 - If a maintainer is no longer interested or cannot perform the maintainer duties listed above, he/she
 should volunteer to be transitioned to emeritus status.
-- If a maintainer is unresponsive for at least one month, he/she can be removed from the maintainers list immediately.
+- If a maintainer is unresponsive, the existing codeowners can decide he/she can be removed from the maintainers list immediately.
 - In extreme cases, this can also occur by a vote of
 the maintainers per the voting process below.
 

--- a/docs/governance/01-governance.md
+++ b/docs/governance/01-governance.md
@@ -51,7 +51,7 @@ Every codeowner is expected to:
   of the existing maintainers.
 * We may ask you to do some PRs from our backlog.
 * As you gain experience with the code base and our standards, we will ask you to do code reviews for incoming PRs (i.e., all maintainers are expected to shoulder a proportional share of community reviews).
-* After working together and making sure you deeply understand the code base, and are comfortable with submitting reviews, the existing codeowners can make a decision to add you to the maintainers list. A candidate for maintainer should create an issue in the [community](https://github.com/kyma-project/community) repository with a list of his/her current contributions. The existing maintainers will confer and decide whether to grant the maintainer status or not.
+* After working together and making sure you deeply understand the code base, and are comfortable with submitting reviews, the existing codeowners can make a decision to add you to the maintainers list. To request approval, the candidate creates an issue in the [community](https://github.com/kyma-project/community) repository with a list of his/her current contributions. The existing maintainers will confer and decide whether to grant the maintainer status or not.
 
 >**NOTE:** To be accepted as a maintainer and be added to Kyma GitHub organizations, you need to have [two-factor authentication](https://help.github.com/en/articles/about-two-factor-authentication) enabled on your GitHub account.
 

--- a/docs/governance/01-governance.md
+++ b/docs/governance/01-governance.md
@@ -59,7 +59,7 @@ Every codeowner is expected to:
 
 - If a maintainer is no longer interested or cannot perform the maintainer duties listed above, he/she
 should volunteer to be transitioned to emeritus status.
-- If a maintainer is unresponsive for at least 3 months, he/she can be removed from the maintainers list immediately.
+- If a maintainer is unresponsive for at least one month, he/she can be removed from the maintainers list immediately.
 - In extreme cases, this can also occur by a vote of
 the maintainers per the voting process below.
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

The [current guidelines](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md#when-does-a-maintainer-lose-the-maintainer-status) set a very precise timelines for when to add/remove people to/from codeowners, which may be inconvenient and disrupt transparency of the reviewers list.

I suggested shortening this time period and in the team discussion, it was agreed that every team should have a final say on when to add/remove team members to/from codeowners. 

Changes proposed in this pull request:

- Change the time period of unresponsiveness after which a codeowner gains/loses his/her owner rights

**Related issues:**
https://github.com/kyma-project/community/issues/614