### PR TITLE
Change how to write 2-dimensional table-tests

### DIFF
--- a/concepts/eventing-code-guidelines.md
+++ b/concepts/eventing-code-guidelines.md
@@ -724,7 +724,7 @@ func TestSomething(t *testing.T) {
 <details>
   <summary>2-dimensional table-driven test</summary>
 
-You may encounter a situation where a table-driven test requires more than one dimension. The following shows a best practice example for a 2-dimensional table-driven test.
+There may be situation when you need a table-driven test with more than one dimension. The following shows a best practice example for a 2-dimensional table-driven test.
 
 ```go
 func TestTwoDimensions(t *testing.T) {
@@ -769,10 +769,10 @@ func TestTwoDimensions(t *testing.T) {
   <summary>Reason for variable reassignment (tc := tc)</summary>
 
 The loop iteration variable in Go is a single variable. The closure for the second t.Run is executed inside a goroutine. 
-If there are multiple entries in the `cloudEvents` struct, `ce` will reference the last entry in `cloudEvents` in every iteration. The problem only occurs because the closure referring to `tc` and `ce` is not executed in **sync** with the **for loop** (because of t.parallel).
-To prevent this problem, `ce` and `tc` need to be copied (`ce := ce`).
+If there are multiple entries in the `cloudEvents` struct, `ce` references the last entry in `cloudEvents` in every iteration. The problem occurs because the closure referring to `tc` and `ce` is not executed in **sync** with the **for loop** (because of t.parallel).
+To prevent this problem, `ce` and `tc` must be copied (`ce := ce`).
 The linter [scopelint](https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/scopelint.go) warns about the possible problem whenever `ce` or `testCase` is used.
-Adding `// nolint:scopelint` to silence scopelint has to be used with caution.
+Adding `// nolint:scopelint` to silence scopelint must be used with caution.
 
 **See Also**:
 - [Go Wiki - Common Mistakes](https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables)
@@ -783,7 +783,7 @@ Adding `// nolint:scopelint` to silence scopelint has to be used with caution.
 <details>
   <summary>Reason for using nested t.Run</summary>
 
-In order to understand the reasoning for using t.Run in a nested way, we need to see the output that both tests produce.
+To understand why we use t.Run in a nested way, look at the output that both tests produce.
 When not using t.Run in a nested way, the test could look like this:
 
 ```go
@@ -824,8 +824,8 @@ PASS
 ok      test    0.182s
 ```
 
-When you look at the output that both examples produce, you can see that the test name is different (`binary_cloud_event_sender_-_proper_cloud_event` vs `binary_cloud_event_sender/proper_cloud_event`). Each subtest will add `/<test_name>` to the test name.
-The **advantage** of using t.Run in a nested way is that:
+When you look at the output of both examples, you can see that the test name is different: (`binary_cloud_event_sender_-_proper_cloud_event` vs `binary_cloud_event_sender/proper_cloud_event`). Each subtest adds `/<test_name>` to the test name.
+The **advantages** of using t.Run in a nested way are that:
 - The test name is easier to read (`binary_cloud_event_sender/proper_cloud_event`).
 - There is no need to use a combined name (`tc.name+" - "+ce.name`).
 - The nesting of t.Run is displayed in a nicer way (in IDEs, this is used to group tests and make them collapsable).

--- a/concepts/eventing-code-guidelines.md
+++ b/concepts/eventing-code-guidelines.md
@@ -752,7 +752,7 @@ func TestTwoDimensions(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			for _, ce := range ce {
+			for _, ce := range cloudEvents {
 				ce := ce
 				t.Run(ce.name, func(t *testing.T) {
 					t.Parallel()
@@ -771,7 +771,7 @@ func TestTwoDimensions(t *testing.T) {
 The loop iteration variable in Go is a single variable. The closure for the second t.Run is executed inside a goroutine. 
 If there are multiple entries in the `cloudEvents` struct, `ce` references the last entry in `cloudEvents` in every iteration. The problem occurs because the closure referring to `tc` and `ce` is not executed in **sync** with the **for loop** (because of t.parallel).
 To prevent this problem, `ce` and `tc` must be copied (`ce := ce`).
-The linter [scopelint](https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/scopelint.go) warns about the possible problem whenever `ce` or `testCase` is used.
+The linter [scopelint](https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/scopelint.go) warns about the possible problem whenever `ce` or `tc` is used.
 Adding `// nolint:scopelint` to silence scopelint must be used with caution.
 
 **See Also**:
@@ -825,7 +825,7 @@ ok      test    0.182s
 ```
 
 When you look at the output of both examples, you can see that the test name is different: (`binary_cloud_event_sender_-_proper_cloud_event` vs `binary_cloud_event_sender/proper_cloud_event`). Each subtest adds `/<test_name>` to the test name.
-The **advantages** of using t.Run in a nested way are that:
+The **advantages** of using t.Run in a nested way are:
 - The test name is easier to read (`binary_cloud_event_sender/proper_cloud_event`).
 - There is no need to use a combined name (`tc.name+" - "+ce.name`).
 - The nesting of t.Run is displayed in a nicer way (in IDEs, this is used to group tests and make them collapsable).

--- a/concepts/eventing-code-guidelines.md
+++ b/concepts/eventing-code-guidelines.md
@@ -772,7 +772,8 @@ The loop iteration variable in Go is a single variable. The closure for the seco
 If there are multiple entries in the `cloudEvents` struct, `ce` references the last entry in `cloudEvents` in every iteration. The problem occurs because the closure referring to `tc` and `ce` is not executed in **sync** with the **for loop** (because of t.parallel).
 To prevent this problem, `ce` and `tc` must be copied (`ce := ce`).
 The linter [scopelint](https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/scopelint.go) warns about the possible problem whenever `ce` or `tc` is used.
-Adding `// nolint:scopelint` to silence scopelint must be used with caution.
+
+>**CAUTION:** If you add `// nolint:scopelint` to silence scopelint, you might not notice when `ce` or `tc` references the wrong entry in the test case list.
 
 **See Also**:
 - [Go Wiki - Common Mistakes](https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables)

--- a/concepts/eventing-code-guidelines.md
+++ b/concepts/eventing-code-guidelines.md
@@ -708,6 +708,7 @@ func TestSomething(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			res := functionUnderTest(tc.givenAttribute)
 			// check res == tc.wantAttribute
@@ -749,7 +750,7 @@ func TestTwoDimensions(t *testing.T) {
 		{
 			name:               "proper cloud event",
 			givenCEType:        "order.created.v1",
-			wantHTTPStatusCode: http.StatusOK.
+			wantHTTPStatusCode: http.StatusOK,
 		},
 	}
 	for _, tc := range testCases {
@@ -991,13 +992,16 @@ func TestNatsHandlerForCloudEvents(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-	  t.Run(tc.name, func(t *testing.T) {
-		for _, ceTestCase := range handlertest.TestCasesForCloudEvents {
-			t.Run(ceTestCase.Name, func(t *testing.T) {
-			// other code is unchanged
-			})
-		}
-	})
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			for _, ceTestCase := range handlertest.TestCasesForCloudEvents {
+				ceTestCase := ceTestCase  
+				t.Run(ceTestCase.Name, func(t *testing.T) {
+					// other code is unchanged
+				})
+			}
+		})
+	}
 }
 ```
 </details>

--- a/concepts/eventing-code-guidelines.md
+++ b/concepts/eventing-code-guidelines.md
@@ -692,7 +692,7 @@ They also provide context and meaning to the test cases.
 - To improve readability, always set the **field names** when initializing the test case struct.
 
 <details>
-  <summary>Example</summary>
+  <summary>Normal table-driven test</summary>
 
 ```go
 func TestSomething(t *testing.T) {
@@ -716,12 +716,6 @@ func TestSomething(t *testing.T) {
 	}
 }
 ```
-
-<details>
-  <summary>Reason for variable reassignment (tc := tc)</summary>
-//TODO(nils):
-
-</details>
 
 </details>
 
@@ -768,6 +762,21 @@ func TestTwoDimensions(t *testing.T) {
 	}
 }
 ```
+
+<details>
+  <summary>Reason for variable reassignment (tc := tc)</summary>
+
+The loop iteration variable in Go is a single variable. The closure for the second t.Run is executed inside a goroutine. 
+If there are multiple entries in the `cloudEvents` struct, `ce` will reference the last entry in `cloudEvents` in every iteration. The problem only occurs because the closure referring to `tc` and `ce` is not executed in **sync** with the **for loop** (because of t.parallel).
+To prevent this problem, `ce` and `tc` need to be copied (`ce := ce`).
+The linter [scopelint](https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/scopelint.go) warns about the possible problem whenever `ce` or `testCase` is used.
+Adding `// nolint:scopelint` to silence scopelint has to be used with caution.
+
+**See Also**:
+- [Go Wiki - Common Mistakes](https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables)
+- [Example when using t.Parallel and for loops in table-driven tests](https://gist.github.com/posener/92a55c4cd441fc5e5e85f27bca008721) 
+
+</details>
 
 <details>
   <summary>Reason for using nested t.Run</summary>

--- a/concepts/eventing-code-guidelines.md
+++ b/concepts/eventing-code-guidelines.md
@@ -904,9 +904,9 @@ Let us assume that `tc.name` is equal to `parent test name` and `ceTestCase.Name
 
 When you look at the output that both examples produce, you can see that the test name is different (`parent_test_name_-_child_test_name` vs `parent_test_name/child_test_name`). Each subtest will add `/<test_name>` to the test name.
 The **advantage** of using t.Run in a nested way is that:
-1. The test name is easier to read (`parent_test_name/child_test_name`).
-2. There is no need to use a combined name (`tc.name+" - "+ceTestCase.name`).
-3. The nesting of t.Run is displayed in a nicer way (in IDEs this is used to group tests and make them collapsable).
+- The test name is easier to read (`parent_test_name/child_test_name`).
+- There is no need to use a combined name (`tc.name+" - "+ceTestCase.name`).
+- The nesting of t.Run is displayed in a nicer way (in IDEs, this is used to group tests and make them collapsable).
 
 <details>
   <summary>Example using one t.Run</summary>

--- a/concepts/eventing-code-guidelines.md
+++ b/concepts/eventing-code-guidelines.md
@@ -724,7 +724,7 @@ func TestSomething(t *testing.T) {
 <details>
   <summary>2-dimensional table-driven test</summary>
 
-There may be situation when you need a table-driven test with more than one dimension. The following shows a best practice example for a 2-dimensional table-driven test.
+There may be situations when you need a table-driven test with more than one dimension. See the following best practice example for a 2-dimensional table-driven test:
 
 ```go
 func TestTwoDimensions(t *testing.T) {

--- a/concepts/eventing-code-guidelines.md
+++ b/concepts/eventing-code-guidelines.md
@@ -772,11 +772,10 @@ func TestTwoDimensions(t *testing.T) {
   <summary>Reason for using nested t.Run</summary>
 
 //TODO(nils): context needs to be rewritten to new example
-Let us assume that `tc.name` is equal to `parent test name` and `ceTestCase.Name` is equal to `child test name`.
 
-When you look at the output that both examples produce, you can see that the test name is different (`parent_test_name_-_child_test_name` vs `parent_test_name/child_test_name`). Each subtest will add `/<test_name>` to the test name.
+When you look at the output that both examples produce, you can see that the test name is different (`binary_cloud_event_sender_-_proper_cloud_event` vs `binary_cloud_event_sender/proper_cloud_event`). Each subtest will add `/<test_name>` to the test name.
 The **advantage** of using t.Run in a nested way is that:
-- The test name is easier to read (`parent_test_name/child_test_name`).
+- The test name is easier to read (`binary_cloud_event_sender/proper_cloud_event`).
 - There is no need to use a combined name (`tc.name+" - "+ceTestCase.name`).
 - The nesting of t.Run is displayed in a nicer way (in IDEs, this is used to group tests and make them collapsable).
 
@@ -793,9 +792,9 @@ The **advantage** of using t.Run in a nested way is that:
 
 $ go test -v
 === RUN   TestNatsHandlerForCloudEvents
-=== RUN   TestNatsHandlerForCloudEvents/parent_test_name_-_child_test_name
+=== RUN   TestNatsHandlerForCloudEvents/binary_cloud_event_sender_-_proper_cloud_event
 --- PASS: TestNatsHandlerForCloudEvents (0.00s)
-    --- PASS: TestNatsHandlerForCloudEvents/parent_test_name_-_child_test_name (0.00s)
+    --- PASS: TestNatsHandlerForCloudEvents/binary_cloud_event_sender_-_proper_cloud_event (0.00s)
 PASS
 ok      test    0.199s
 ```
@@ -817,11 +816,11 @@ ok      test    0.199s
 
 $ go test -v
 === RUN   TestNatsHandlerForCloudEvents
-=== RUN   TestNatsHandlerForCloudEvents/parent_test_name
-=== RUN   TestNatsHandlerForCloudEvents/parent_test_name/child_test_name
+=== RUN   TestNatsHandlerForCloudEvents/binary_cloud_event_sender
+=== RUN   TestNatsHandlerForCloudEvents/binary_cloud_event_sender/proper_cloud_event
 --- PASS: TestNatsHandlerForCloudEvents (0.00s)
-    --- PASS: TestNatsHandlerForCloudEvents/parent_test_name (0.00s)
-        --- PASS: TestNatsHandlerForCloudEvents/parent_test_name/child_test_name
+    --- PASS: TestNatsHandlerForCloudEvents/binary_cloud_event_sender (0.00s)
+        --- PASS: TestNatsHandlerForCloudEvents/binary_cloud_event_sender/proper_cloud_event
  (0.00s)
 PASS
 ok      test    0.182s

--- a/concepts/eventing-code-guidelines.md
+++ b/concepts/eventing-code-guidelines.md
@@ -667,14 +667,14 @@ The [Given-When-Then](https://en.wikipedia.org/wiki/Given-When-Then) pattern is 
 // given
 // create a subscription using the mocked client
 sub, err := client.Create(subscription)
-g.Expect(err).ToNot(BeNil())
+assert.NotNil(t, err)
 
 // when
 // call the function
 functionUnderTest(sub)
 
 // then
-g.Expect(sub).To(BeNil())
+assert.Nil(t, sub)
 ```
 
 Sometimes you need to add more comments to the tests (in addition to the GWT comments). We recommend to add them underneath the GWT comments.

--- a/concepts/eventing-code-guidelines.md
+++ b/concepts/eventing-code-guidelines.md
@@ -691,6 +691,8 @@ They also provide context and meaning to the test cases.
   - Keep the `name` short. For example, use **"event order.created received"** instead of "test that event order.created was received" or "ensure that event order.created was received".
 - To improve readability, always set the **field names** when initializing the test case struct.
 
+#### Best practice
+
 <details>
   <summary>Normal table-driven test</summary>
 

--- a/concepts/eventing-code-guidelines.md
+++ b/concepts/eventing-code-guidelines.md
@@ -882,6 +882,7 @@ func TestSomething(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			res := functionUnderTest(tc.givenAttribute)
 			fmt.Println(res)

--- a/concepts/eventing-code-guidelines.md
+++ b/concepts/eventing-code-guidelines.md
@@ -722,7 +722,7 @@ func TestSomething(t *testing.T) {
 <details>
   <summary>2-dimensional table-driven test</summary>
 
-You may encounter a situation where a table-driven test requires more than one  dimension. The following shows a best practice for a 2-dimensional table-driven test.
+You may encounter a situation where a table-driven test requires more than one dimension. The following shows a best practice example for a 2-dimensional table-driven test.
 
 ```go
 func TestTwoDimensions(t *testing.T) {
@@ -751,7 +751,7 @@ func TestTwoDimensions(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			for _, ce := range ce {
- 				ce := ce
+				ce := ce
 				t.Run(ce.name, func(t *testing.T) {
 					t.Parallel()
 					res := functionUnderTest(tc.givenSender, ce.givenCEType)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Use `nested t.Run` in `2-dimensional` table-driven test
- Migrate GWT example to testify (cleanup since we decided to not use gomega as assertion library anymore).

**Motivation**
While reviewing the PR [Refactor Event publisher proxy tests #13549](https://github.com/kyma-project/kyma/pull/13549/files#diff-c4c06f2b2d05560c98fba9a96123631b1ea616ed19fcd65fb3c857783ffa5245R95), @marcobebway and me talked about his way of implementing a 2-dimensional table test vs what the code guidelines currently propose.
The argumentation why his way of doing it is the better one, is described in the guidelines itself.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
