### PR TITLE
Add missing doc-regeneration step

### DIFF
--- a/docs/guidelines/releases-guidelines/03-kyma-cli-release-process.md
+++ b/docs/guidelines/releases-guidelines/03-kyma-cli-release-process.md
@@ -26,6 +26,7 @@ A Kyma CLI release consists of:
    ```
 2. Check the `internal/config/config.go` file from the `cli` repository on the release branch:
    - The `DefaultKyma2Version` variable must contain the latest Kyma `2.x.x` version.
+   - Run `make docs` to update the CLI help accordingly.
 
 3. Create a PR to `cli/release-x.y` that triggers the presubmit job for `cli`.
 


### PR DESCRIPTION
**Description**

Add missing doc-regeneration step for the CLI release guide.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
