### PR TITLE
Fix general documents links in Document types templates

### DIFF
--- a/docs/guidelines/templates/templates-type.md
+++ b/docs/guidelines/templates/templates-type.md
@@ -12,7 +12,7 @@ This table contains templates for general documents.
 
 | Repository | Template | Usage | Author |
 |---|---|---|---|
-| All | [`README.md`](https://github.com/kyma-project/community/blob/main/templates/repository-template/README.md) | Use the template for the `README.md` document in any repository, directory, or subdirectory within the Kyma organization. | All contributors |
+| All | [`README.md`](https://github.com/kyma-project/template-repository/blob/main/README.md) | Use the template for the `README.md` document in any repository, directory, or subdirectory within the Kyma organization. | All contributors |
 
 ## Document types for Kyma areas and components
 

--- a/docs/guidelines/templates/templates-type.md
+++ b/docs/guidelines/templates/templates-type.md
@@ -8,11 +8,10 @@ Use a particular document type template to be consistent with the Kyma standards
 
 ## General documents
 
-This table contains templates for general documents, such as `NOTES.txt` and `README.md` document types.
+This table contains templates for general documents.
 
 | Repository | Template | Usage | Author |
 |---|---|---|---|
-| [`kyma`](https://github.com/kyma-project/kyma)| [`NOTES.txt`](https://github.com/kyma-project/community/blob/main/templates/resources/NOTES.txt) | Use the template for charts. | All contributors |
 | All | [`README.md`](https://github.com/kyma-project/community/blob/main/templates/repository-template/README.md) | Use the template for the `README.md` document in any repository, directory, or subdirectory within the Kyma organization. | All contributors |
 
 ## Document types for Kyma areas and components


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Remove NOTES.txt (template for charts)
- fix the link to the README.md template

**Related issue(s)**
Resolves #721 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
