### PR TITLE
Remove the `manifesto-app` from the CODEOENWRS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,6 @@
 # Default owners of the repository
 * @mmitoraj @majakurcius @NHingerl @grego952 @IwonaLanger  
 
-# Owners of the manifesto-app folder
-/manifesto-app/ @m00g3n @pPrecel @dbadura @kwiatekus @moelsayed @cortey
-
 # Owners of the sigs-and-wgs folder
 /sigs-and-wgs/ @PK85
 


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Remove the `manifesto-app` from the CODEOENWRS file because it does not exist
