### PR TITLE
Fix broken links

### DIFF
--- a/docs/kyma-release-notes/2023-08-04-release-notes-2.17.md
+++ b/docs/kyma-release-notes/2023-08-04-release-notes-2.17.md
@@ -5,7 +5,7 @@
 ### Monitoring
 - We have introduced new [production profile settings](https://github.com/kyma-project/kyma/pull/17652). 
 - We have updated the [dashboard/datasource reloader](https://github.com/kyma-project/kyma/pull/17812). The logs to `stdout` are now reduced to a minimum.
-- We have updated the [Monitoring stack]((https://github.com/kyma-project/kyma/pull/17877)):
+- We have updated the [Monitoring stack](https://github.com/kyma-project/kyma/pull/17877):
   - Prometheus to version 2.45.0 LTS
   - Prometheus-operator to version 0.66.0
 

--- a/emeritus.md
+++ b/emeritus.md
@@ -26,7 +26,7 @@ This file lists all maintainers that are no longer actively contributing to the 
 * Sayan Hazra (**[@sayanh](https://github.com/sayanh)**) involved in `area/eventing`, `area/serverless`.
 * Suleyman Akbas (**[@suleymanakbas91](https://github.com/suleymanakbas91)**) involved in `area/cli`, `area/logging`, `area/tracing`, `area/monitoring`, `area/performance`.
 * Adam Wałach (**[@adamwalach](https://github.com/adamwalach)**) involved in `area/ci` and `area/service-catalog`.
-* Jose Cortina (**[@jose-cortina](https://github.com/jose-cortina)**) involved in `area/community`.
+* Jose Cortina involved in `area/community`.
 * Kamil Sputo (**[@ksputo](https://github.com/ksputo)**) involved in `area/service-catalog` and  `area/control-plane`.
 * Mostafa Shorim (**[@shorim](https://github.com/shorim)**) involved in `area/cli`, `area/logging`, `area/tracing`, `area/monitoring`.
 * Pranav Shankar (**[@Pranav-SA](https://github.com/Pranav-SA)**) involved in `area/logging`, `area/tracing`, `area/monitoring`.


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Fixed a link in the release notes for Kyma 2.17
- removed the link to a non-existing account from the `emeritus.md` file


