### PR TITLE
Add tj-actions/changed-files to allowed actions

### DIFF
--- a/docs/contributing/assets/allowed_actions.json
+++ b/docs/contributing/assets/allowed_actions.json
@@ -152,6 +152,17 @@
       "security_review_performed": true,
       "3rd_party_tool": {},
       "comment": "can be used to perform a docker command without switching the job image"
+    },
+    {
+      "name": "tj-actions/changed-files",
+      "versions": [
+        "90a06d6ba9543371ab4df8eeca0be07ca6054959"
+      ],
+      "repository": "https://github.com/tj-actions/changed-files",
+      "marketplace": "https://github.com/marketplace/actions/changed-files",
+      "security_review_performed": true,
+      "3rd_party_tool": {},
+      "comment": "track all changed files and directories relative to a target branch, the current branch, multiple branches, or custom commits"
     }
   ]
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Add an action to track changed files. This will be used to track what is changed in a PR, in order to skip unnecessary jobs in workflows that are required to pass by branch protection. The default path filtering provided by github actions is not sufficient, as it can only skip an entire workflow, so it doesn't report any status and the PR can't be merged.

Changes proposed in this pull request:

- Add tj-actions/changed-files to allowed actions

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
