### PR TITLE
adds golangci/golangci-lint-action@v4 to the allowed actions

### DIFF
--- a/docs/contributing/assets/allowed_actions.json
+++ b/docs/contributing/assets/allowed_actions.json
@@ -27,7 +27,7 @@
       "security_review_performed": true,
       "3rd_party_tool": {
         "tool": "golangci-lint",
-        "pinned_version": "???",
+        "pinned_version": "v1.56.2",
         "repository": "https://github.com/golangci/golangci-lint"
       },
       "comment": ""

--- a/docs/contributing/assets/allowed_actions.json
+++ b/docs/contributing/assets/allowed_actions.json
@@ -17,6 +17,22 @@
       "comment": ""
     },
     {
+      "name": "golangci/golangci-lint-action",
+      "versions": [
+        "3cfe3a4abbb849e10058ce4af15d205b6da42804",
+        "v4"
+      ],
+      "repository": "https://github.com/golangci/golangci-lint-action",
+      "marketplace": "https://github.com/marketplace/actions/run-golangci-lint",
+      "security_review_performed": true,
+      "3rd_party_tool": {
+        "tool": "golangci-lint",
+        "pinned_version": "???",
+        "repository": "https://github.com/golangci/golangci-lint"
+      },
+      "comment": ""
+    },
+    {
       "name": "AbsaOSS/k3d-action",
       "versions": [
         "4e8b3239042be1dc0aed6c5eb80c13b18200fc79"

--- a/docs/contributing/assets/allowed_actions.json
+++ b/docs/contributing/assets/allowed_actions.json
@@ -20,7 +20,7 @@
       "name": "golangci/golangci-lint-action",
       "versions": [
         "3cfe3a4abbb849e10058ce4af15d205b6da42804",
-        "v4"
+        "v4.0.0"
       ],
       "repository": "https://github.com/golangci/golangci-lint-action",
       "marketplace": "https://github.com/marketplace/actions/run-golangci-lint",


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- adds golangci/golangci-lint-action@v4 to the allowed actions
- ...
- ...

**Related issue(s)**
Unblocks:
- https://github.com/kyma-project/kyma/pull/18579
- https://github.com/kyma-project/infrastructure-manager/pull/144
