### PR TITLE
Unordered lists are appropriate for items that have no sequential order

### DIFF
--- a/sigs-and-wgs/archive/sig-core/proposals/central-connector-service.md
+++ b/sigs-and-wgs/archive/sig-core/proposals/central-connector-service.md
@@ -15,13 +15,13 @@ As the customers work with multiple Kyma clusters, they will benefit from extend
 
 ## Goal
 
-1. The Connector service can be deployed outside of Kyma cluster
-1. The Connector service handles client certificate provisioning for the connection with the Application Registry.
-1. The Connector service handles client certificate provisioning for the connection with the Event Service.
-1. The Connector service handles certificate provisioning for Kyma cluster.
-1. The Connector service handles certificate rotation.
-1. The Connector service handles certificate revocation.
-1. The Connector service returns information about the available cluster endpoints.
+- The Connector service can be deployed outside of Kyma cluster
+- The Connector service handles client certificate provisioning for the connection with the Application Registry.
+- The Connector service handles client certificate provisioning for the connection with the Event Service.
+- The Connector service handles certificate provisioning for Kyma cluster.
+- The Connector service handles certificate rotation.
+- The Connector service handles certificate revocation.
+- The Connector service returns information about the available cluster endpoints.
 
 ## Suggested solution
 


### PR DESCRIPTION
## Description

Doc adjustment according to the [guideline](https://github.com/kyma-project/community/blob/main/docs/guidelines/content-guidelines/03-formatting.md#ordered-and-unordered-lists) 

> use lists to create visual clarity within your content. List items in a category or in a sequence. Use an ordered list for sequential, instructional steps. Unordered lists are appropriate for items that have no sequential order, such as a list of valid file types. Follow these guidelines: 