### PR TITLE
Add gitleaks/gitleaks-action action to allowed actions

### DIFF
--- a/docs/contributing/assets/allowed_actions.json
+++ b/docs/contributing/assets/allowed_actions.json
@@ -179,6 +179,21 @@
       "security_review_performed": true,
       "3rd_party_tool": {},
       "comment": "track all changed files and directories relative to a target branch, the current branch, multiple branches, or custom commits"
+    },
+    {
+      "name": "gitleaks/gitleaks-action",
+      "versions": [
+        "e6dab246340401bf53eec993b8f05aebe80ac636"
+      ],
+      "repository": "https://github.com/gitleaks/gitleaks-action",
+      "marketplace": "https://github.com/marketplace/actions/gitleaks",
+      "security_review_performed": true,
+      "3rd_party_tool": {
+        "tool": "gitleaks/gitleaks",
+        "pinned_version": "v8.16.1",
+        "repository": "https://github.com/gitleaks/gitleaks"
+      },
+      "comment": "Detects leaks of secrets using gitleaks, pinned to 8.16.1 by default but can be changed via environment variable"
     }
   ]
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Add gitleaks/gitleaks-action v.23.4 to allowed action by exact commit

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
