### PR TITLE
Fix a broken link to OpenCensus docs

### DIFF
--- a/concepts/observability-strategy/configurable-tracing/pocs/w3c-tracecontext/README.md
+++ b/concepts/observability-strategy/configurable-tracing/pocs/w3c-tracecontext/README.md
@@ -26,7 +26,7 @@ So the PoC used the traditional approach with the meshConfig and a hardcoded pro
 7. Call `GET demo.<yourClusterDomain>`.
 8. Check Jaeger `kubectl port-forward -n kyma-system svc/tracing-jaeger-query 16686:16686`.
 
-The activation of the openCensusAgent as tracer with the [extensionProvider](https://istio.io/latest/docs/tasks/observability/distributed-tracing/opencensusagent/) concept was tried as well. It required to use Istio 1.15 and worked out very well by changing the Istio config to use the following settings:
+The activation of the openCensusAgent as tracer with the [extensionProvider](https://github.com/istio/istio.io/blob/release-1.22/content/en/docs/tasks/observability/distributed-tracing/opencensusagent/index.md) concept was tried as well. It required to use Istio 1.15 and worked out very well by changing the Istio config to use the following settings:
 ```yaml
   defaultProviders:
     tracing: ["opencensus"]


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Fix a broken link in [w3c tracecontext POC](https://github.com/kyma-project/community/tree/main/concepts/observability-strategy/configurable-tracing/pocs/w3c-tracecontext) to point to 1.22 branch of Istio. The new release 1.23 does not include the OpenCensus documentation

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
