### PR TITLE
Add allcheckspassed to allowed_actions.json

### DIFF
--- a/docs/contributing/assets/allowed_actions.json
+++ b/docs/contributing/assets/allowed_actions.json
@@ -206,6 +206,17 @@
         "repository": "https://github.com/gitleaks/gitleaks"
       },
       "comment": "Detects leaks of secrets using gitleaks, pinned to 8.16.1 by default but can be changed via environment variable"
+    },
+    {
+      "name": "wechuli/allcheckspassed",
+      "versions": [
+        "2e5e8bbc775f5680ed5d02e3a22e2fc7219792ac"
+      ],
+      "repository": "https://github.com/wechuli/allcheckspassed",
+      "marketplace": "https://github.com/marketplace/actions/allcheckspassed",
+      "security_review_performed": true,
+      "3rd_party_tool": {},
+      "comment": "This action will check that all checks have passed on a given pull request"
     }
   ]
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Add `allcheckspassed` GHA to `allowed_actions.json` in order to use it as an alternative to prow/tide's "all jobs succeeded" logic in our GHA pipeline

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
