### PR TITLE
Remove an obsolete link

### DIFF
--- a/sigs-and-wgs/archive/wg-showcase-application/README.md
+++ b/sigs-and-wgs/archive/wg-showcase-application/README.md
@@ -18,7 +18,6 @@ The purpose of this Working Group (WG) is to build a Unified Demo Project with a
 
 * [Slack](https://kyma-community.slack.com/archives/C01C40T8CKD)
 * [Open community issues and pull requests](https://github.com/kyma-project/community/labels/area%2Fcommunity)
-* [Project Board](https://github.com/kyma-project/community/projects/5)
 
 ## Meetings
 


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Remove the link to the community project board; there's no such project.
