### PR TITLE
Remove inappropriate versions from allowed actions list

### DIFF
--- a/docs/contributing/assets/allowed_actions.json
+++ b/docs/contributing/assets/allowed_actions.json
@@ -3,29 +3,14 @@
     {
       "name": "golangci/golangci-lint-action",
       "versions": [
-        "639cd343e1d3b897ff35927a75193d57cfcba299",
-        "v3"
-      ],
-      "repository": "https://github.com/golangci/golangci-lint-action",
-      "marketplace": "https://github.com/marketplace/actions/run-golangci-lint",
-      "security_review_performed": true,
-      "3rd_party_tool": {
-        "tool": "golangci-lint",
-        "pinned_version": "???",
-        "repository": "https://github.com/golangci/golangci-lint"
-      },
-      "comment": ""
-    },
-    {
-      "name": "golangci/golangci-lint-action",
-      "versions": [
         "a4f60bb28d35aeee14e6880718e0c85ff1882e64",
         "9d1e0624a798bb64f6c3cea93db47765312263dc",
         "3cfe3a4abbb849e10058ce4af15d205b6da42804",
         "v4.0.0",
         "v6.0.1",
         "v6.1.0",
-        "aaa42aa0628b4ae2578232a66b541047968fac86"
+        "aaa42aa0628b4ae2578232a66b541047968fac86",
+        "639cd343e1d3b897ff35927a75193d57cfcba299"
       ],
       "repository": "https://github.com/golangci/golangci-lint-action",
       "marketplace": "https://github.com/marketplace/actions/run-golangci-lint",
@@ -76,8 +61,7 @@
     {
       "name": "autotelic/action-wait-for-status-check",
       "versions": [
-        "6556cf50c8fb6608412945382eae73581f56cbb4",
-        "v1"
+        "6556cf50c8fb6608412945382eae73581f56cbb4"
       ],
       "repository": "https://github.com/autotelic/action-wait-for-status-check",
       "marketplace": "https://github.com/marketplace/actions/wait-for-github-status-check",
@@ -88,8 +72,7 @@
     {
       "name": "gaurav-nelson/github-action-markdown-link-check",
       "versions": [
-        "d53a906aa6b22b8979d33bc86170567e619495ec",
-        "v1"
+        "d53a906aa6b22b8979d33bc86170567e619495ec"
       ],
       "repository": "https://github.com/gaurav-nelson/github-action-markdown-link-check",
       "marketplace": "https://github.com/marketplace/actions/markdown-link-check",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

Remove the following versions from the list of allowed actions because the version number is not valid according to the guidelines:

- autotelic/action-wait-for-status-check@v1
- gaurav-nelson/github-action-markdown-link-check@v1
- golangci/golangci-lint-action@v3

Consolidated the 2 entries of the action `golangci/golangci-lint-action`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
