### PR TITLE
chore: Add golangci-lint-action v6.1.1 to allowlist

### DIFF
--- a/docs/contributing/assets/allowed_actions.json
+++ b/docs/contributing/assets/allowed_actions.json
@@ -3,14 +3,16 @@
     {
       "name": "golangci/golangci-lint-action",
       "versions": [
-        "a4f60bb28d35aeee14e6880718e0c85ff1882e64",
         "9d1e0624a798bb64f6c3cea93db47765312263dc",
-        "3cfe3a4abbb849e10058ce4af15d205b6da42804",
+        "639cd343e1d3b897ff35927a75193d57cfcba299",
         "v4.0.0",
+        "3cfe3a4abbb849e10058ce4af15d205b6da42804",
         "v6.0.1",
+        "a4f60bb28d35aeee14e6880718e0c85ff1882e64",
         "v6.1.0",
         "aaa42aa0628b4ae2578232a66b541047968fac86",
-        "639cd343e1d3b897ff35927a75193d57cfcba299"
+        "v6.1.1",
+        "971e284b6050e8a5849b72094c50ab08da042db8"
       ],
       "repository": "https://github.com/golangci/golangci-lint-action",
       "marketplace": "https://github.com/marketplace/actions/run-golangci-lint",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- adds `v6.1.1` (hash `971e284b6050e8a5849b72094c50ab08da042db8`) to allowlist
- orders list to have the related hash directly following the version

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
