### PR TITLE
Remove link from image-syncer section

### DIFF
--- a/docs/guidelines/technical-guidelines/02-docker-images.md
+++ b/docs/guidelines/technical-guidelines/02-docker-images.md
@@ -48,9 +48,7 @@ See the repository content for more information.
 
 ### Image Syncer
 
-If you want to "cache" an image from an external registry, use the [image-syncer
-](https://github.com/kyma-project/test-infra/tree/main/cmd/image-syncer)
-tool.
+If you want to "cache" an image from an external registry, use the image-syncer tool.
 
 To copy the image to our registry, modify the `external-images.yaml` file in your repository.
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- image-syncer is now removed from GH https://github.com/kyma-project/test-infra/pull/13879

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
