### PR TITLE
Fix broken link to image-builder docs

### DIFF
--- a/docs/guidelines/technical-guidelines/02-docker-images.md
+++ b/docs/guidelines/technical-guidelines/02-docker-images.md
@@ -57,12 +57,12 @@ This URL can then be used in your Helm charts.
 
 ## Image Builder Documentation
 
-For building Docker images within Kyma, refer to the [image-builder documentation](https://github.com/kyma-project/test-infra/tree/main/cmd/image-builder).
+For building Docker images within Kyma, refer to the [image-builder documentation](https://pages.github.tools.sap/kyma/documentation/kyma-internal/how-to-guides/090-build-oci-images-with-image-builder.html).
 Image Builder is designed to streamline the process of creating and publishing Docker images for Kyma components.
 
 ### Dockerfile Recommendations
 
-The [Dockerfile recommendations](https://github.com/kyma-project/test-infra/blob/main/cmd/image-builder/README.md#L206)
+The [Dockerfile recommendations](https://pages.github.tools.sap/kyma/documentation/kyma-internal/how-to-guides/090-build-oci-images-with-image-builder.html#key-recommendations)
 provide guidance on cross-compiling and caching strategies for non-native architecture builds, ensuring better performance and compatibility.
 When preparing Dockerfiles for Kyma projects, ensure that you incorporate these practices to optimize build processes.
 

--- a/docs/guidelines/technical-guidelines/02-docker-images.md
+++ b/docs/guidelines/technical-guidelines/02-docker-images.md
@@ -60,7 +60,14 @@ This URL can then be used in your Helm charts.
 For building Docker images within Kyma, refer to the [image-builder documentation](https://pages.github.tools.sap/kyma/documentation/kyma-internal/how-to-guides/090-build-oci-images-with-image-builder.html).
 Image Builder is designed to streamline the process of creating and publishing Docker images for Kyma components.
 
-### Dockerfile Recommendations
+## Cross-Compiling and Caching for Non-Native Architecture Builds
+
+Image Builder uses builder agents with `linux/amd64` native architecture.
+When building images for multiple architectures or building an image for a non-native architecture,
+consider enabling cross-compilation to significantly reduce build times.
+Testing has shown that cross-compilation can speed up the build process by **10x**, reducing build times from 12 minutes to less than 2 minutes in our test scenario with a rather small golang codebase.
+
+### Key Recommendations
 
 - Cross-Compilation: If you are building non-native architecture images, implement cross-compilation in your Dockerfile, use
   the [Faster Multi-Platform Builds: Dockerfile Cross-Compilation Guide](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/)

--- a/docs/guidelines/technical-guidelines/02-docker-images.md
+++ b/docs/guidelines/technical-guidelines/02-docker-images.md
@@ -62,46 +62,46 @@ Image Builder is designed to streamline the process of creating and publishing D
 
 ### Dockerfile Recommendations
 
-The [Dockerfile recommendations](https://pages.github.tools.sap/kyma/documentation/kyma-internal/how-to-guides/090-build-oci-images-with-image-builder.html#key-recommendations)
-provide guidance on cross-compiling and caching strategies for non-native architecture builds, ensuring better performance and compatibility.
-When preparing Dockerfiles for Kyma projects, ensure that you incorporate these practices to optimize build processes.
+- Cross-Compilation: If you are building non-native architecture images, implement cross-compilation in your Dockerfile, use
+  the [Faster Multi-Platform Builds: Dockerfile Cross-Compilation Guide](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/)
+  as a reference.
+- Bind Mounts: To avoid copying source code for compilation, use bind mounts for the `RUN` command in Dockerfiles.
+  However, the speed gain was minimal in our tests: We achieved a speedup of less than ~5 seconds.
+- Cache Mounts for Go Compiler:
+  Rely on a cache backed by a remote repository, because a new agent is allocated for each pipeline execution, making mount-type caching
+  ineffective.
+  Use mounts a cache type for Go package downloads. The binary compilation cache did not increase speed during tests.
 
-## Examples
+### Example Dockerfile to Build Publicly Available Images
 
-Go from scratch:
+```dockerfile
+FROM --platform=$BUILDPLATFORM golang:1.24.2-alpine3.21 AS builder
 
-```Dockerfile
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download -x
+
+ARG TARGETOS TARGETARCH
+RUN --mount=target=. cd /app/cmd/image-builder && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -buildvcs=false -o /image-builder -a -ldflags '-extldflags "-static"' .
+
 FROM scratch
-LABEL source=git@github.com:kyma-project/examples.git
 
-ADD main /
-CMD ["/main"]
+COPY --from=builder /image-builder /image-builder
+
+ENTRYPOINT ["/image-builder"]
 ```
 
-Go from alpine:
+### Example Dockerfile to Build Restricted Images
 
-```Dockerfile
-FROM alpine:3.7
-RUN apk --no-cache upgrade && apk --no-cache add curl
+```dockerfile
+FROM europe-docker.pkg.dev/kyma-project/restricted-dev/sap.com/python-fips:latest
+WORKDIR /app
 
-LABEL source=git@github.com:kyma-project/examples.git
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
 
-ADD main /
-CMD ["/main"]
-```
+COPY . .
 
-JavaScript from nginx:
-
-```Dockerfile
-FROM nginx:1.13-alpine
-RUN apk --no-cache upgrade
-
-LABEL source=git@github.com:kyma-project/examples.git
-
-COPY nginx.conf /etc/nginx/nginx.conf
-COPY /build var/public
-
-EXPOSE 80
-
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["python", "-m", "your_module"]
 ```

--- a/docs/guidelines/technical-guidelines/02-docker-images.md
+++ b/docs/guidelines/technical-guidelines/02-docker-images.md
@@ -57,7 +57,7 @@ This URL can then be used in your Helm charts.
 
 ## Image Builder Documentation
 
-For building Docker images within Kyma, refer to the [image-builder documentation](https://github.com/kyma-project/test-infra/blob/main/cmd/image-builder/README.md).
+For building Docker images within Kyma, refer to the [image-builder documentation](https://github.com/kyma-project/test-infra/tree/main/cmd/image-builder).
 Image Builder is designed to streamline the process of creating and publishing Docker images for Kyma components.
 
 ### Dockerfile Recommendations


### PR DESCRIPTION
Fixes broken link to image-builder README that no longer exists (https://github.com/kyma-project/test-infra/pull/14168)