### PR TITLE
Add preposition guideline for "cluster"

### DIFF
--- a/docs/guidelines/content-guidelines/04-style-and-terminology.md
+++ b/docs/guidelines/content-guidelines/04-style-and-terminology.md
@@ -65,6 +65,14 @@ Whenever you refer to the name of our product or one of our components, don't us
 ✅ Application Connector  
 ⛔️ the Application Connector
 
+### Prepositions
+
+Use "in" or "to" when referring to a cluster — never "on". This follows the Kubernetes upstream documentation convention.
+
+✅ The Pod runs **in** your cluster.
+✅ Deploy a Function **to** the cluster.
+⛔️ Deploy a Function **on** the cluster.
+
 ### Punctuation
 
 Use colons and semicolons sparingly. Use the colon ( : ) to introduce a list of things. The semicolon ( ; ) separates two distinct clauses within one sentence. The phrase after a semicolon is a complete sentence. However, the preferred method is without a colon or semicolon.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Adds a rule to use "in" or "to" with "cluster", never "on". Based on Kubernetes upstream convention and existing usage across Kyma docs (69 "in" + 27 "to" vs. 18 "on", mostly in archived meeting notes).

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
